### PR TITLE
Tensor Like

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "tch"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "half 1.8.2",
  "lazy_static",
@@ -1160,7 +1160,7 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "torch-sys"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
 name = "raddar_derive"
 version = "0.1.0"
 dependencies = [
+ "derive_builder",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "tch"
-version = "0.9.0"
+version = "0.8.0"
 dependencies = [
  "half 1.8.2",
  "lazy_static",
@@ -1160,7 +1160,7 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "torch-sys"
-version = "0.9.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/raddar_derive/Cargo.lock
+++ b/raddar_derive/Cargo.lock
@@ -3,6 +3,84 @@
 version = 3
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +102,17 @@ dependencies = [
 name = "raddar_derive"
 version = "0.1.0"
 dependencies = [
+ "derive_builder",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/raddar_derive/Cargo.toml
+++ b/raddar_derive/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 syn = { version = "1.0.103", features = ["full", "extra-traits", "parsing"] }
 quote = "1.0"
 proc-macro2 = "1.0.47"
+derive_builder = "0.11.2"

--- a/raddar_derive/src/lib.rs
+++ b/raddar_derive/src/lib.rs
@@ -2,9 +2,14 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{self, parse::Parser};
+use syn::{self, parse::Parser, Ident};
 
-#[proc_macro_derive(CallableModule)]
+#[derive(Debug, Clone, Default)]
+struct ModuleAttr {
+    pub tensor_type: Option<Ident>,
+}
+
+#[proc_macro_derive(CallableModule, attributes(module))]
 pub fn callable_module_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
 
@@ -13,43 +18,51 @@ pub fn callable_module_derive(input: TokenStream) -> TokenStream {
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let tensor_type = extract_module_attr(&ast.attrs).tensor_type;
+    let (impl_generics, tensor_type) = if let Some(tensor_type) = tensor_type {
+        (quote! { #impl_generics }, quote! { #tensor_type })
+    } else {
+        let type_params = generics.type_params();
+        (quote! { <Ts: raddar::core::TensorNN, #(#type_params),*> }, quote! { Ts })
+    };
+
     let gen = quote! {
-        impl #impl_generics Fn<(&Tensor, )> for #name #ty_generics #where_clause {
-            extern "rust-call" fn call(&self, input: (&Tensor, )) -> tch::Tensor {
+        impl #impl_generics Fn<(& #tensor_type, )> for #name #ty_generics #where_clause {
+            extern "rust-call" fn call(&self, input: (& #tensor_type, )) -> #tensor_type {
                 self.forward(input.0)
             }
         }
 
-        impl #impl_generics FnMut<(&Tensor, )> for #name #ty_generics #where_clause {
-            extern "rust-call" fn call_mut(&mut self, input: (&Tensor, )) -> tch::Tensor {
+        impl #impl_generics FnMut<(& #tensor_type, )> for #name #ty_generics #where_clause {
+            extern "rust-call" fn call_mut(&mut self, input: (& #tensor_type, )) -> #tensor_type {
                 self.forward(input.0)
             }
         }
 
-        impl #impl_generics FnOnce<(&Tensor, )> for #name #ty_generics #where_clause {
-            type Output = Tensor;
+        impl #impl_generics FnOnce<(& #tensor_type, )> for #name #ty_generics #where_clause {
+            type Output = #tensor_type;
 
-            extern "rust-call" fn call_once(self, input: (&Tensor, )) -> Tensor {
+            extern "rust-call" fn call_once(self, input: (& #tensor_type, )) -> #tensor_type {
                 self.forward(input.0)
             }
         }
 
-        impl #impl_generics Fn<(&Tensor, )> for raddar::nn::Mod<#name #ty_generics> #where_clause {
-            extern "rust-call" fn call(&self, input: (&Tensor, )) -> tch::Tensor {
+        impl #impl_generics Fn<(& #tensor_type, )> for raddar::nn::Mod<#name #ty_generics, #tensor_type> #where_clause {
+            extern "rust-call" fn call(&self, input: (& #tensor_type, )) -> #tensor_type {
                 self.module().forward(input.0)
             }
         }
 
-        impl #impl_generics FnMut<(&Tensor, )> for raddar::nn::Mod<#name #ty_generics> #where_clause {
-            extern "rust-call" fn call_mut(&mut self, input: (&Tensor, )) -> tch::Tensor {
+        impl #impl_generics FnMut<(& #tensor_type, )> for raddar::nn::Mod<#name #ty_generics, #tensor_type> #where_clause {
+            extern "rust-call" fn call_mut(&mut self, input: (& #tensor_type, )) -> #tensor_type {
                 self.module().forward(input.0)
             }
         }
 
-        impl #impl_generics FnOnce<(&Tensor, )> for raddar::nn::Mod<#name #ty_generics> #where_clause {
-            type Output = Tensor;
+        impl #impl_generics FnOnce<(& #tensor_type, )> for raddar::nn::Mod<#name #ty_generics, #tensor_type> #where_clause {
+            type Output = #tensor_type;
 
-            extern "rust-call" fn call_once(self, input: (&Tensor, )) -> Tensor {
+            extern "rust-call" fn call_once(self, input: (& #tensor_type, )) -> #tensor_type {
                 self.module().forward(input.0)
             }
         }
@@ -57,7 +70,7 @@ pub fn callable_module_derive(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-#[proc_macro_derive(NonParameterModule)]
+#[proc_macro_derive(NonParameterModule, attributes(module))]
 pub fn non_parameter_module_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
 
@@ -66,15 +79,62 @@ pub fn non_parameter_module_derive(input: TokenStream) -> TokenStream {
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let gen = quote! {
-        impl #impl_generics raddar::nn::NonParameterModule for #name #ty_generics #where_clause {}
+    let tensor_type = extract_module_attr(&ast.attrs).tensor_type;
+
+    let gen = if let Some(tensor_type) = tensor_type {
+        quote! {
+            impl #impl_generics raddar::nn::Trainable<#tensor_type> for #name #ty_generics #where_clause {}
+        }
+    } else {
+        let type_params = generics.type_params();
+        quote! {
+            impl<Ts: raddar::core::TensorNN, #(#type_params),*> raddar::nn::Trainable<Ts> for #name #ty_generics #where_clause {}
+        }
     };
     gen.into()
+}
+
+#[proc_macro_derive(NonParameterModuleAny)]
+pub fn non_parameter_module_any_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+
+    let name = &ast.ident;
+
+    let generics = &ast.generics;
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let type_params = generics.type_params();
+
+    let gen = quote! {
+        impl<Ts: raddar::core::TensorNN, #(#type_params),*> raddar::nn::Trainable<Ts> for #name #ty_generics #where_clause {}
+    };
+    gen.into()
+}
+
+fn extract_module_attr(attrs: &[syn::Attribute]) -> ModuleAttr {
+    let mut module_attr = ModuleAttr::default();
+    for attr in attrs {
+        if let syn::Meta::List(list) = attr.parse_meta().unwrap() {
+            if list.path.is_ident("module") {
+                for nested in list.nested {
+                    if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = nested {
+                        if name_value.path.is_ident("tensor_type") {
+                            if let syn::Lit::Str(lit_str) = name_value.lit {
+                                module_attr.tensor_type = Some(lit_str.parse().unwrap());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    module_attr
 }
 
 #[proc_macro_derive(
     ArchitectureBuilder,
     attributes(
+        module,
         builder,
         builder_field_attr,
         builder_impl_attr,
@@ -84,23 +144,38 @@ pub fn non_parameter_module_derive(input: TokenStream) -> TokenStream {
 )]
 pub fn architecture_builder_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input.clone()).unwrap();
+    
+    let data_struct = match ast.data {
+        syn::Data::Struct(data_struct) => data_struct,
+        _ => panic!("ArchitectureBuilder can only be derived for structs"),
+    };
 
-    let builder_fields = match ast.data {
-        syn::Data::Struct(syn::DataStruct {
-            fields: syn::Fields::Named(syn::FieldsNamed { named, .. }),
-            ..
-        }) => named
-            .into_iter()
-            .filter(|field| {
-                field.attrs.iter().any(|attr| {
-                    attr.path.is_ident("builder")
-                        || attr.path.is_ident("builder_field_attr")
-                        || attr.path.is_ident("builder_impl_attr")
-                        || attr.path.is_ident("builder_setter_attr")
-                        || attr.path.is_ident("builder_struct_attr")
+    let tensor_type = extract_module_attr(&ast.attrs).tensor_type;
+
+    let builder_fields = match data_struct.fields{
+        syn::Fields::Named(syn::FieldsNamed { named, .. }) => {
+            let mut named = named
+                .into_iter()
+                .filter(|field| {
+                    field.attrs.iter().any(|attr| {
+                        attr.path.is_ident("builder")
+                            || attr.path.is_ident("builder_field_attr")
+                            || attr.path.is_ident("builder_impl_attr")
+                            || attr.path.is_ident("builder_setter_attr")
+                            || attr.path.is_ident("builder_struct_attr")
+                    })
                 })
-            })
-            .collect::<Vec<_>>(),
+                .collect::<Vec<_>>();
+            if let Some(tensor_type) = tensor_type.as_ref() {
+                named.push(syn::Field::parse_named
+                    .parse2(quote! {
+                        #[builder(default="std::marker::PhantomData")]
+                        _marker_ts: std::marker::PhantomData<#tensor_type>
+                    })
+                    .unwrap());
+            }
+            named
+        },
         _ => panic!("ArchitectureBuilder can only be used on structs with named fields"),
     };
 
@@ -111,19 +186,36 @@ pub fn architecture_builder_derive(input: TokenStream) -> TokenStream {
 
     let builder_name = syn::Ident::new(&format!("{}Builder", name), name.span());
     let builder_name_str = syn::LitStr::new(&builder_name.to_string(), builder_name.span());
-    let output = quote! {
-        #[derive(derive_builder::Builder, Clone, Debug)]
-        #[builder(pattern = "owned", name = #builder_name_str, build_fn(private, name = "build_config"))]
-        pub struct #config_name #impl_generics #where_clause {
-            #(#builder_fields),*
+    let output = if let Some(tensor_type) = tensor_type.as_ref() {
+        quote! {
+            #[derive(derive_builder::Builder, Clone, Debug)]
+            #[builder(pattern = "owned", name = #builder_name_str, build_fn(private, name = "build_config"))]
+            pub struct #config_name #impl_generics #where_clause {
+                #(#builder_fields),*
+            }
+    
+            impl #impl_generics #builder_name #ty_generics #where_clause {
+                pub fn build(self) -> raddar::nn::Mod<#name #ty_generics, #tensor_type> {
+                    raddar::nn::Mod::new(#name::new(self.build_config().unwrap()))
+                }
+            }
         }
-
-        impl #impl_generics #builder_name #ty_generics #where_clause {
-            pub fn build(self) -> raddar::nn::Mod<#name #ty_generics> {
-                raddar::nn::Mod::new(#name::new(self.build_config().unwrap()))
+    } else {
+        quote! {
+            #[derive(derive_builder::Builder, Clone, Debug)]
+            #[builder(pattern = "owned", name = #builder_name_str, build_fn(private, name = "build_config"))]
+            pub struct #config_name #impl_generics #where_clause {
+                #(#builder_fields),*
+            }
+    
+            impl #impl_generics #builder_name #ty_generics #where_clause {
+                pub fn build<Ts: raddar::core::TensorNN>(self) -> raddar::nn::Mod<#name #ty_generics, Ts> {
+                    raddar::nn::Mod::new(#name::new(self.build_config().unwrap()))
+                }
             }
         }
     };
+     
     output.into()
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,4 @@
 pub use tensor::*;
+pub use tensor_like::*;
 pub mod tensor;
+pub mod tensor_like;

--- a/src/core/tensor.rs
+++ b/src/core/tensor.rs
@@ -222,12 +222,12 @@ impl<
 }
 
 /// Convert a multi-dimensional array to tensor.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use raddar::tensor;
-/// 
+///
 /// let a = tensor!([[0, 1], [2, 3]]);
 /// let b = tensor!([0]);
 /// let c = tensor!([0.2]);

--- a/src/core/tensor.rs
+++ b/src/core/tensor.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use tch::{kind::Element, Tensor};
 
-pub type TensorCell = Arc<Mutex<Tensor>>;
+use super::TensorLike;
 
-pub trait Cellable {
-    fn cell(self) -> TensorCell;
+pub type TensorCell<T: TensorLike> = Arc<Mutex<T>>;
+
+pub trait Cellable<T: TensorLike> {
+    fn cell(self) -> TensorCell<T>;
 }
 
 pub trait TensorIntoIter {
@@ -44,8 +46,8 @@ impl Iterator for TensorIter {
     }
 }
 
-impl Cellable for Tensor {
-    fn cell(self) -> TensorCell {
+impl<T: TensorLike> Cellable<T> for T {
+    fn cell(self) -> TensorCell<T> {
         Arc::new(Mutex::new(self))
     }
 }

--- a/src/core/tensor_like.rs
+++ b/src/core/tensor_like.rs
@@ -1,10 +1,11 @@
 use std::{
     borrow::Borrow,
     fmt::Debug,
-    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign}, path::Path,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    path::Path,
 };
 
-use tch::{Device, Kind, Tensor};
+use tch::{Device, Kind, Tensor, Scalar};
 
 pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
 pub trait AddScalar<T> = Add<f64, Output = T> + Add<i64, Output = T> where T: Sized;
@@ -92,7 +93,7 @@ pub trait DivAssignTrait = DivAssign<Self>
 
 pub trait NegTrait = Neg<Output = Self> + for<'a> Neg<Output = Self> + Sized;
 
-pub trait Element: Clone + tch::kind::Element {}
+pub trait Element: Clone + tch::kind::Element + Into<Scalar> {}
 
 impl Element for u8 {}
 impl Element for i8 {}
@@ -104,27 +105,14 @@ impl Element for f64 {}
 impl Element for bool {}
 
 /// A trait for a tensor-like object.
-/// 
+///
 /// A tensor-like object should have the following properties:
-/// - It should be able to perform element-wise operations, including addition, subtraction, multiplication, division, negation, and element-wise comparison, with other tensor-like objects.
 /// - It should be associated with some env variable, which for example may be used to determine the device and data type of the tensor-like object, and a size indicating the length of each dimension.
 /// - It should be able to be constructed with some factors, or other tensor-like objects.
 /// - It should also be able to perform some other operations, such as reshaping, transposing, and slicing.
-pub trait TensorLike:
-    AddTrait
-    + SubTrait
-    + MulTrait
-    + DivTrait
-    + AddAssignTrait
-    + SubAssignTrait
-    + MulAssignTrait
-    + DivAssignTrait
-    + NegTrait
-    + PartialEq<Self>
-    + AsRef<Self>
-    + Debug
-    + Default
-{
+///
+/// Of course, a real tensor-like object should also be able to perform some tensor operations, such as arithmetic operations, matrix multiplication, gradient calculation, and so on. However, this trait just focuses on the properties of tensor-like objects, and does not require further functions.
+pub trait TensorLike: PartialEq<Self> + AsRef<Self> + Debug + Default {
     /// The type of the env variable.
     type Env: Default;
 
@@ -134,32 +122,259 @@ pub trait TensorLike:
     /// Get the size of the tensor-like object.
     fn size(&self) -> Vec<i64>;
 
-    /// Create 
+    /// Create a tensor-like object from a slice.
     fn of_slice<T: Element>(data: &[T]) -> Self;
-    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
-    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
-    fn concat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
 
+    /// Stack a list of tensor-like objects into a tensor-like object.
+    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+
+    /// Concatenate a list of tensor-like objects into a tensor-like object.
+    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+
+    /// Create a tensor-like object filled with zeros.
     fn zeros(size: &[i64], env: Self::Env) -> Self;
+
+    /// Create a tensor-like object filled with ones.
     fn ones(size: &[i64], env: Self::Env) -> Self;
+
+    /// Create a tensor-like object filled with uninitialized values.
     fn empty(size: &[i64], env: Self::Env) -> Self;
 
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with zeros.
     fn zeros_like(&self) -> Self {
         Self::zeros(&self.size(), self.env())
     }
 
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with ones.
     fn ones_like(&self) -> Self {
         Self::ones(&self.size(), self.env())
     }
 
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with uninitialized values.
     fn empty_like(&self) -> Self {
         Self::empty(&self.size(), self.env())
     }
 
+    /// Create a 2-D tensor-like object with ones on the diagonal and zeros elsewhere.
     fn eye(size: i64, env: Self::Env) -> Self;
 
+    /// Read named tensor-like objects from a .npz file.
     fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
+
+    /// Read named tensor-like objects from a .ot file.
     fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
+
+    /// Copy the tensor-like object to self.
+    fn copy_(&mut self, other: &Self);
+
+    /// Copy to a new tensor-like object.
+    fn copy(&self) -> Self {
+        let mut result = self.empty_like();
+        result.copy_(self);
+        result
+    }
+
+    /// Fill the tensor-like object with given value.
+    fn fill_(&mut self, value: impl Element);
+
+    /// Uniformly fill the tensor-like object with values in the given range.
+    fn uniform_(&mut self, low: f64, high: f64);
+
+    /// Initialize the tensor-like object with values from kaiming uniform distribution.
+    fn kaiming_uniform_(&mut self) {
+        let fan_in: i64 = self.size().iter().skip(1).product();
+        let bound = (1.0 / fan_in as f64).sqrt();
+        self.uniform_(-bound, bound);
+    }
+
+    /// Reshape the tensor-like object as the given size.
+    fn reshape(&self, size: &[i64]) -> Self;
+
+    /// Reshape the tensor-like object as the same size as the given tensor-like object.
+    fn reshape_as(&self, other: &Self) -> Self {
+        self.reshape(&other.size())
+    }
+
+    /// View the tensor-like object as the given size.
+    fn view(&self, size: &[i64]) -> Self;
+
+    /// View the tensor-like object as the same size as the given tensor-like object.
+    fn view_as(&self, other: &Self) -> Self {
+        self.view(&other.size())
+    }
+}
+
+/// A trait for a tensor-like object that can perform basic algebraic operations, including arithmetic operations, matrix multiplication, trigonometric functions, and so on.
+///
+/// Some more advanced operations, such as gradient calculation, convolution, and so on, are not included in this trait.
+pub trait TensorOps:
+    TensorLike
+    + AddTrait
+    + SubTrait
+    + MulTrait
+    + DivTrait
+    + AddAssignTrait
+    + SubAssignTrait
+    + MulAssignTrait
+    + DivAssignTrait
+    + NegTrait
+{
+    /// Calculate the sum of all elements in the tensor-like object.
+    fn sum(&self) -> Self;
+
+    /// Calculate the sum of each row of the tensor-like object in the given dimensions `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    fn sum_dim(&self, dim: &[i64], keep_dim: bool) -> Self;
+
+    /// Calculate the mean of all elements in the tensor-like object.
+    fn mean(&self) -> Self;
+
+    /// Calculate the mean of each row of the tensor-like object in the given dimensions `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    fn mean_dim(&self, dim: &[i64], keep_dim: bool) -> Self;
+
+    /// Calculate the maximum of all elements in the tensor-like object.
+    fn max(&self) -> Self;
+
+    /// Calculate the maximum of each row of the tensor-like object in the given dimension `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    /// 
+    /// Returns a tuple of the maximum value and the index of the maximum value.
+    fn max_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self);
+
+    /// Calculate the minimum of all elements in the tensor-like object.
+    fn min(&self) -> Self;
+
+    /// Calculate the minimum of each row of the tensor-like object in the given dimension `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    /// 
+    /// Returns a tuple of the minimum value and the index of the minimum value.
+    fn min_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self);
+
+    /// Calculate the argmax of all elements in the tensor-like object.
+    fn argmax(&self) -> Self;
+
+    /// Calculate the argmax of each row of the tensor-like object in the given dimension `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    fn argmax_dim(&self, dim: i64, keep_dim: bool) -> Self;
+
+    /// Calculate the argmin of all elements in the tensor-like object.
+    fn argmin(&self) -> Self;
+
+    /// Calculate the argmin of each row of the tensor-like object in the given dimension `dim`.
+    /// 
+    /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
+    fn argmin_dim(&self, dim: i64, keep_dim: bool) -> Self;
+
+    /// Calculate the transpose of the tensor-like object.
+    fn transpose(&self, dim0: i64, dim1: i64) -> Self;
+
+    /// Calculate the matrix multiplication of the tensor-like object and the given tensor-like object.
+    fn matmul<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Calculate the absolute value of the tensor-like object.
+    fn abs(&self) -> Self;
+
+    /// Calculate the element-wise square of the tensor-like object.
+    fn square(&self) -> Self;
+
+    /// Calculate the element-wise square root of the tensor-like object.
+    fn sqrt(&self) -> Self;
+
+    /// Calculate the element-wise exponential of the tensor-like object.
+    fn exp(&self) -> Self;
+
+    /// Calculate the element-wise natural logarithm of the tensor-like object.
+    fn log(&self) -> Self;
+
+    /// Calculate the element-wise sine of the tensor-like object.
+    fn sin(&self) -> Self;
+
+    /// Calculate the element-wise cosine of the tensor-like object.
+    fn cos(&self) -> Self;
+
+    /// Calculate the element-wise tangent of the tensor-like object.
+    fn tan(&self) -> Self;
+
+    /// Calculate the element-wise hyperbolic sine of the tensor-like object.
+    fn sinh(&self) -> Self;
+
+    /// Calculate the element-wise hyperbolic cosine of the tensor-like object.
+    fn cosh(&self) -> Self;
+
+    /// Calculate the element-wise hyperbolic tangent of the tensor-like object.
+    fn tanh(&self) -> Self;
+
+    /// Calculate the element-wise inverse sine of the tensor-like object.
+    fn asin(&self) -> Self;
+
+    /// Calculate the element-wise inverse cosine of the tensor-like object.
+    fn acos(&self) -> Self;
+
+    /// Calculate the element-wise inverse tangent of the tensor-like object.
+    fn atan(&self) -> Self;
+
+    /// Calculate the element-wise inverse hyperbolic sine of the tensor-like object.
+    fn asinh(&self) -> Self;
+
+    /// Calculate the element-wise inverse hyperbolic cosine of the tensor-like object.
+    fn acosh(&self) -> Self;
+
+    /// Calculate the element-wise inverse hyperbolic tangent of the tensor-like object.
+    fn atanh(&self) -> Self;
+
+    /// Compute the element-wise less-than comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn lt<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise less-than comparison of the tensor-like object and the given scalar.
+    fn lt_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Compute the element-wise less-than-or-equal comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn le<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise less-than-or-equal comparison of the tensor-like object and the given scalar.
+    fn le_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Compute the element-wise greater-than comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn gt<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise greater-than comparison of the tensor-like object and the given scalar.
+    fn gt_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Compute the element-wise greater-than-or-equal comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn ge<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise greater-than-or-equal comparison of the tensor-like object and the given scalar.
+    fn ge_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Compute the element-wise equality comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn eq<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise equality comparison of the tensor-like object and the given scalar.
+    fn eq_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Compute the element-wise inequality comparison of the tensor-like object and the given tensor-like object.
+    /// 
+    /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
+    fn ne<T: Borrow<Self>>(&self, other: T) -> Self;
+
+    /// Compute the element-wise inequality comparison of the tensor-like object and the given scalar.
+    fn ne_scalar<S: Element>(&self, other: S) -> Self;
 }
 
 impl TensorLike for Tensor {
@@ -185,10 +400,6 @@ impl TensorLike for Tensor {
         Tensor::cat(tensors, dim)
     }
 
-    fn concat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
-        Tensor::concat(tensors, dim)
-    }
-
     fn zeros(size: &[i64], env: Self::Env) -> Self {
         Tensor::zeros(size, env)
     }
@@ -211,5 +422,199 @@ impl TensorLike for Tensor {
 
     fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
         Ok(Tensor::load_multi(path)?)
+    }
+
+    fn copy_(&mut self, other: &Self) {
+        Tensor::copy_(self, other)
+    }
+
+    fn fill_(&mut self, value: impl Element) {
+        let _ = Tensor::fill_(self, value);
+    }
+
+    fn uniform_(&mut self, low: f64, high: f64) {
+        let _ = Tensor::uniform_(self, low, high);
+    }
+
+    fn reshape(&self, size: &[i64]) -> Self {
+        Tensor::reshape(self, size)
+    }
+    
+    fn view(&self, size: &[i64]) -> Self {
+        Tensor::view(self, size)
+    }
+}
+
+impl TensorOps for Tensor {
+    fn sum(&self) -> Self {
+        Tensor::sum(self, self.kind())
+    }
+
+    fn sum_dim(&self, dim: &[i64], keep_dim: bool) -> Self {
+        Tensor::sum_dim_intlist(self, dim, keep_dim, self.kind())
+    }
+
+    fn mean(&self) -> Self {
+        Tensor::mean(self, self.kind())
+    }
+
+    fn mean_dim(&self, dim: &[i64], keep_dim: bool) -> Self {
+        Tensor::mean_dim(self, dim, keep_dim, self.kind())
+    }
+
+    fn max(&self) -> Self {
+        Tensor::max(self)
+    }
+
+    fn max_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self) {
+        Tensor::max_dim(self, dim, keep_dim)
+    }
+
+    fn min(&self) -> Self {
+        Tensor::min(self)
+    }
+
+    fn min_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self) {
+        Tensor::min_dim(self, dim, keep_dim)
+    }
+
+    fn argmax(&self) -> Self {
+        Tensor::argmax(self, None, false)
+    }
+
+    fn argmax_dim(&self, dim: i64, keep_dim: bool) -> Self {
+        Tensor::argmax(self, Some(dim), keep_dim)
+    }
+
+    fn argmin(&self) -> Self {
+        Tensor::argmin(self, None, false)
+    }
+
+    fn argmin_dim(&self, dim: i64, keep_dim: bool) -> Self {
+        Tensor::argmin(self, Some(dim), keep_dim)
+    }
+
+    fn transpose(&self, dim0: i64, dim1: i64) -> Self {
+        Tensor::transpose(self, dim0, dim1)
+    }
+
+    fn matmul<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::matmul(self, other.borrow())
+    }
+    
+    fn abs(&self) -> Self {
+        Tensor::abs(self)
+    }
+
+    fn square(&self) -> Self {
+        Tensor::square(self)
+    }
+
+    fn sqrt(&self) -> Self {
+        Tensor::sqrt(self)
+    }
+
+    fn exp(&self) -> Self {
+        Tensor::exp(self)
+    }
+
+    fn log(&self) -> Self {
+        Tensor::log(self)
+    }
+
+    fn sin(&self) -> Self {
+        Tensor::sin(self)
+    }
+
+    fn cos(&self) -> Self {
+        Tensor::cos(self)
+    }
+
+    fn tan(&self) -> Self {
+        Tensor::tan(self)
+    }
+
+    fn asin(&self) -> Self {
+        Tensor::asin(self)
+    }
+
+    fn acos(&self) -> Self {
+        Tensor::acos(self)
+    }
+
+    fn atan(&self) -> Self {
+        Tensor::atan(self)
+    }
+
+    fn sinh(&self) -> Self {
+        Tensor::sinh(self)
+    }
+
+    fn cosh(&self) -> Self {
+        Tensor::cosh(self)
+    }
+
+    fn tanh(&self) -> Self {
+        Tensor::tanh(self)
+    }
+
+    fn asinh(&self) -> Self {
+        Tensor::asinh(self)
+    }
+
+    fn acosh(&self) -> Self {
+        Tensor::acosh(self)
+    }
+
+    fn atanh(&self) -> Self {
+        Tensor::atanh(self)
+    }
+
+    fn lt<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::less_tensor(self, other.borrow())
+    }
+
+    fn lt_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::less(self, other)
+    }
+
+    fn gt<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::greater_tensor(self, other.borrow())
+    }
+
+    fn gt_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::greater(self, other)
+    }
+
+    fn le<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::le_tensor(self, other.borrow())
+    }
+
+    fn le_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::le(self, other)
+    }
+
+    fn ge<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::ge_tensor(self, other.borrow())
+    }
+
+    fn ge_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::ge(self, other)
+    }
+
+    fn eq<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::eq_tensor(self, other.borrow())
+    }
+
+    fn eq_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::eq(self, other)
+    }
+
+    fn ne<T: Borrow<Self>>(&self, other: T) -> Self {
+        Tensor::ne_tensor(self, other.borrow())
+    }
+
+    fn ne_scalar<S: Element>(&self, other: S) -> Self {
+        Tensor::ne(self, other)
     }
 }

--- a/src/core/tensor_like.rs
+++ b/src/core/tensor_like.rs
@@ -125,6 +125,13 @@ pub trait TensorLike: PartialEq<Self> + AsRef<Self> + Debug + Default {
     /// Create a tensor-like object from a slice.
     fn of_slice<T: Element>(data: &[T]) -> Self;
 
+    /// Create a 2-D tensor-like object from a slice of slices.
+    fn of_slice2<T: Element, U: AsRef<[T]>>(v: &[U]) -> Self
+    {
+        let inner: Vec<Self> = v.iter().map(|v| Self::of_slice(v.as_ref())).collect();
+        Self::stack(&inner, 0)
+    }
+
     /// Stack a list of tensor-like objects into a tensor-like object.
     fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
 

--- a/src/core/tensor_like.rs
+++ b/src/core/tensor_like.rs
@@ -1,0 +1,108 @@
+use std::{ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign, Neg}, fmt::Debug};
+
+use tch::Tensor;
+
+pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
+pub trait AddScalar<T> = Add<f64, Output = T> + Add<i64, Output = T> where T: Sized;
+pub trait AddSelfWith<T> = where T: AddSelf<Self>;
+pub trait AddScalarWith<T> = where T: AddScalar<Self>;
+pub trait AddTrait = AddSelfWith<Self>
+    + for<'a> AddSelfWith<&'a Self>
+    + AddScalarWith<Self>
+    + for<'a> AddScalarWith<&'a Self>
+    + AddSelfWith<f64>
+    + AddSelfWith<i64>
+    + AddSelfWith<f32>
+    + AddSelfWith<i32>;
+
+pub trait SubSelf<T> = Sub<T, Output = T> + for<'a> Sub<&'a T, Output = T> where T: Sized;
+pub trait SubScalar<T> = Sub<f64, Output = T> + Sub<i64, Output = T> where T: Sized;
+pub trait SubSelfWith<T> = where T: SubSelf<Self>;
+pub trait SubScalarWith<T> = where T: SubScalar<Self>;
+pub trait SubTrait = SubSelfWith<Self>
+    + for<'a> SubSelfWith<&'a Self>
+    + SubScalarWith<Self>
+    + for<'a> SubScalarWith<&'a Self>
+    + SubSelfWith<f64>
+    + SubSelfWith<i64>
+    + SubSelfWith<f32>
+    + SubSelfWith<i32>;
+
+pub trait MulSelf<T> = Mul<T, Output = T> + for<'a> Mul<&'a T, Output = T> where T: Sized;
+pub trait MulScalar<T> = Mul<f64, Output = T> + Mul<i64, Output = T> where T: Sized;
+pub trait MulSelfWith<T> = where T: MulSelf<Self>;
+pub trait MulScalarWith<T> = where T: MulScalar<Self>;
+pub trait MulTrait = MulSelfWith<Self>
+    + for<'a> MulSelfWith<&'a Self>
+    + MulScalarWith<Self>
+    + for<'a> MulScalarWith<&'a Self>
+    + MulSelfWith<f64>
+    + MulSelfWith<i64>
+    + MulSelfWith<f32>
+    + MulSelfWith<i32>;
+
+pub trait DivSelf<T> = Div<T, Output = T> + for<'a> Div<&'a T, Output = T> where T: Sized;
+pub trait DivScalar<T> = Div<f64, Output = T> + Div<i64, Output = T> where T: Sized;
+pub trait DivSelfWith<T> = where T: DivSelf<Self>;
+pub trait DivScalarWith<T> = where T: DivScalar<Self>;
+pub trait DivTrait = DivSelfWith<Self>
+    + for<'a> DivSelfWith<&'a Self>
+    + DivScalarWith<Self>
+    + for<'a> DivScalarWith<&'a Self>
+    + DivSelfWith<f64>
+    + DivSelfWith<i64>
+    + DivSelfWith<f32>
+    + DivSelfWith<i32>;
+
+pub trait AddAssignTrait = AddAssign<Self>
+    + for<'a> AddAssign<&'a Self>
+    + AddAssign<f64>
+    + AddAssign<i64>
+    + AddAssign<f32>
+    + AddAssign<i32>
+    + Sized;
+
+pub trait SubAssignTrait = SubAssign<Self>
+    + for<'a> SubAssign<&'a Self>
+    + SubAssign<f64>
+    + SubAssign<i64>
+    + SubAssign<f32>
+    + SubAssign<i32>
+    + Sized;
+
+pub trait MulAssignTrait = MulAssign<Self>
+    + for<'a> MulAssign<&'a Self>
+    + MulAssign<f64>
+    + MulAssign<i64>
+    + MulAssign<f32>
+    + MulAssign<i32>
+    + Sized;
+
+pub trait DivAssignTrait = DivAssign<Self>
+    + for<'a> DivAssign<&'a Self>
+    + DivAssign<f64>
+    + DivAssign<i64>
+    + DivAssign<f32>
+    + DivAssign<i32>
+    + Sized;
+
+pub trait NegTrait = Neg<Output = Self> + for<'a> Neg<Output = Self> + Sized;
+
+pub trait TensorLike:
+    AddTrait
+    + SubTrait
+    + MulTrait
+    + DivTrait
+    + AddAssignTrait
+    + SubAssignTrait
+    + MulAssignTrait
+    + DivAssignTrait
+    + NegTrait
+    + PartialEq<Self>
+    + AsRef<Self>
+    + Debug
+    + Default
+{
+}
+
+impl TensorLike for Tensor {}

--- a/src/core/tensor_like.rs
+++ b/src/core/tensor_like.rs
@@ -1,6 +1,10 @@
-use std::{ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign, Neg}, fmt::Debug};
+use std::{
+    borrow::Borrow,
+    fmt::Debug,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign}, path::Path,
+};
 
-use tch::Tensor;
+use tch::{Device, Kind, Tensor};
 
 pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
 pub trait AddScalar<T> = Add<f64, Output = T> + Add<i64, Output = T> where T: Sized;
@@ -88,6 +92,24 @@ pub trait DivAssignTrait = DivAssign<Self>
 
 pub trait NegTrait = Neg<Output = Self> + for<'a> Neg<Output = Self> + Sized;
 
+pub trait Element: Clone + tch::kind::Element {}
+
+impl Element for u8 {}
+impl Element for i8 {}
+impl Element for i16 {}
+impl Element for i32 {}
+impl Element for i64 {}
+impl Element for f32 {}
+impl Element for f64 {}
+impl Element for bool {}
+
+/// A trait for a tensor-like object.
+/// 
+/// A tensor-like object should have the following properties:
+/// - It should be able to perform element-wise operations, including addition, subtraction, multiplication, division, negation, and element-wise comparison, with other tensor-like objects.
+/// - It should be associated with some env variable, which for example may be used to determine the device and data type of the tensor-like object, and a size indicating the length of each dimension.
+/// - It should be able to be constructed with some factors, or other tensor-like objects.
+/// - It should also be able to perform some other operations, such as reshaping, transposing, and slicing.
 pub trait TensorLike:
     AddTrait
     + SubTrait
@@ -103,6 +125,91 @@ pub trait TensorLike:
     + Debug
     + Default
 {
+    /// The type of the env variable.
+    type Env: Default;
+
+    /// Get the env variable.
+    fn env(&self) -> Self::Env;
+
+    /// Get the size of the tensor-like object.
+    fn size(&self) -> Vec<i64>;
+
+    /// Create 
+    fn of_slice<T: Element>(data: &[T]) -> Self;
+    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+    fn concat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+
+    fn zeros(size: &[i64], env: Self::Env) -> Self;
+    fn ones(size: &[i64], env: Self::Env) -> Self;
+    fn empty(size: &[i64], env: Self::Env) -> Self;
+
+    fn zeros_like(&self) -> Self {
+        Self::zeros(&self.size(), self.env())
+    }
+
+    fn ones_like(&self) -> Self {
+        Self::ones(&self.size(), self.env())
+    }
+
+    fn empty_like(&self) -> Self {
+        Self::empty(&self.size(), self.env())
+    }
+
+    fn eye(size: i64, env: Self::Env) -> Self;
+
+    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
+    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
 }
 
-impl TensorLike for Tensor {}
+impl TensorLike for Tensor {
+    type Env = (Kind, Device);
+
+    fn env(&self) -> Self::Env {
+        (self.kind(), self.device())
+    }
+
+    fn size(&self) -> Vec<i64> {
+        self.size().iter().map(|x| *x as i64).collect()
+    }
+
+    fn of_slice<T: Element>(data: &[T]) -> Self {
+        Tensor::of_slice(data)
+    }
+
+    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
+        Tensor::stack(tensors, dim)
+    }
+
+    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
+        Tensor::cat(tensors, dim)
+    }
+
+    fn concat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
+        Tensor::concat(tensors, dim)
+    }
+
+    fn zeros(size: &[i64], env: Self::Env) -> Self {
+        Tensor::zeros(size, env)
+    }
+
+    fn ones(size: &[i64], env: Self::Env) -> Self {
+        Tensor::ones(size, env)
+    }
+
+    fn empty(size: &[i64], env: Self::Env) -> Self {
+        Tensor::empty(size, env)
+    }
+
+    fn eye(size: i64, env: Self::Env) -> Self {
+        Tensor::eye(size, env)
+    }
+
+    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
+        Ok(Tensor::read_npz(path)?)
+    }
+
+    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
+        Ok(Tensor::load_multi(path)?)
+    }
+}

--- a/src/core/tensor_like/mod.rs
+++ b/src/core/tensor_like/mod.rs
@@ -1,4 +1,6 @@
 pub mod tensor_ops;
+pub mod tensor_ops_ex;
+pub mod tensor_trans;
 
 use std::{
     borrow::Borrow,
@@ -9,6 +11,7 @@ use std::{
 use tch::{Device, Kind, Tensor, Scalar};
 
 pub use tensor_ops::*;
+pub use tensor_ops_ex::*;
 
 pub trait Element: Clone + tch::kind::Element + Into<Scalar> {}
 

--- a/src/core/tensor_like/mod.rs
+++ b/src/core/tensor_like/mod.rs
@@ -1,0 +1,197 @@
+pub mod tensor_ops;
+
+use std::{
+    borrow::Borrow,
+    fmt::Debug,
+    path::Path,
+};
+
+use tch::{Device, Kind, Tensor, Scalar};
+
+pub use tensor_ops::*;
+
+pub trait Element: Clone + tch::kind::Element + Into<Scalar> {}
+
+impl Element for u8 {}
+impl Element for i8 {}
+impl Element for i16 {}
+impl Element for i32 {}
+impl Element for i64 {}
+impl Element for f32 {}
+impl Element for f64 {}
+impl Element for bool {}
+
+/// A trait for a tensor-like object.
+///
+/// A tensor-like object should have the following properties:
+/// - It should be associated with some env variable, which for example may be used to determine the device and data type of the tensor-like object, and a size indicating the length of each dimension.
+/// - It should be able to be constructed with some factors, or other tensor-like objects.
+/// - It should also be able to perform some other operations, such as reshaping, transposing, and slicing.
+///
+/// Of course, a real tensor-like object should also be able to perform some tensor operations, such as arithmetic operations, matrix multiplication, gradient calculation, and so on. However, this trait just focuses on the properties of tensor-like objects, and does not require further functions.
+pub trait TensorLike: PartialEq<Self> + AsRef<Self> + Debug + Default {
+    /// The type of the env variable.
+    type Env: Default;
+
+    /// Get the env variable.
+    fn env(&self) -> Self::Env;
+
+    /// Get the size of the tensor-like object.
+    fn size(&self) -> Vec<i64>;
+
+    /// Create a tensor-like object from a slice.
+    fn of_slice<T: Element>(data: &[T]) -> Self;
+
+    /// Create a 2-D tensor-like object from a slice of slices.
+    fn of_slice2<T: Element, U: AsRef<[T]>>(v: &[U]) -> Self
+    {
+        let inner: Vec<Self> = v.iter().map(|v| Self::of_slice(v.as_ref())).collect();
+        Self::stack(&inner, 0)
+    }
+
+    /// Stack a list of tensor-like objects into a tensor-like object.
+    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+
+    /// Concatenate a list of tensor-like objects into a tensor-like object.
+    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
+
+    /// Create a tensor-like object filled with zeros.
+    fn zeros(size: &[i64], env: Self::Env) -> Self;
+
+    /// Create a tensor-like object filled with ones.
+    fn ones(size: &[i64], env: Self::Env) -> Self;
+
+    /// Create a tensor-like object filled with uninitialized values.
+    fn empty(size: &[i64], env: Self::Env) -> Self;
+
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with zeros.
+    fn zeros_like(&self) -> Self {
+        Self::zeros(&self.size(), self.env())
+    }
+
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with ones.
+    fn ones_like(&self) -> Self {
+        Self::ones(&self.size(), self.env())
+    }
+
+    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with uninitialized values.
+    fn empty_like(&self) -> Self {
+        Self::empty(&self.size(), self.env())
+    }
+
+    /// Create a 2-D tensor-like object with ones on the diagonal and zeros elsewhere.
+    fn eye(size: i64, env: Self::Env) -> Self;
+
+    /// Read named tensor-like objects from a .npz file.
+    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
+
+    /// Read named tensor-like objects from a .ot file.
+    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
+
+    /// Copy the tensor-like object to self.
+    fn copy_(&mut self, other: &Self);
+
+    /// Copy to a new tensor-like object.
+    fn copy(&self) -> Self {
+        let mut result = self.empty_like();
+        result.copy_(self);
+        result
+    }
+
+    /// Fill the tensor-like object with given value.
+    fn fill_(&mut self, value: impl Element);
+
+    /// Uniformly fill the tensor-like object with values in the given range.
+    fn uniform_(&mut self, low: f64, high: f64);
+
+    /// Initialize the tensor-like object with values from kaiming uniform distribution.
+    fn kaiming_uniform_(&mut self) {
+        let fan_in: i64 = self.size().iter().skip(1).product();
+        let bound = (1.0 / fan_in as f64).sqrt();
+        self.uniform_(-bound, bound);
+    }
+
+    /// Reshape the tensor-like object as the given size.
+    fn reshape(&self, size: &[i64]) -> Self;
+
+    /// Reshape the tensor-like object as the same size as the given tensor-like object.
+    fn reshape_as(&self, other: &Self) -> Self {
+        self.reshape(&other.size())
+    }
+
+    /// View the tensor-like object as the given size.
+    fn view(&self, size: &[i64]) -> Self;
+
+    /// View the tensor-like object as the same size as the given tensor-like object.
+    fn view_as(&self, other: &Self) -> Self {
+        self.view(&other.size())
+    }
+}
+
+impl TensorLike for Tensor {
+    type Env = (Kind, Device);
+
+    fn env(&self) -> Self::Env {
+        (self.kind(), self.device())
+    }
+
+    fn size(&self) -> Vec<i64> {
+        self.size().iter().map(|x| *x as i64).collect()
+    }
+
+    fn of_slice<T: Element>(data: &[T]) -> Self {
+        Tensor::of_slice(data)
+    }
+
+    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
+        Tensor::stack(tensors, dim)
+    }
+
+    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
+        Tensor::cat(tensors, dim)
+    }
+
+    fn zeros(size: &[i64], env: Self::Env) -> Self {
+        Tensor::zeros(size, env)
+    }
+
+    fn ones(size: &[i64], env: Self::Env) -> Self {
+        Tensor::ones(size, env)
+    }
+
+    fn empty(size: &[i64], env: Self::Env) -> Self {
+        Tensor::empty(size, env)
+    }
+
+    fn eye(size: i64, env: Self::Env) -> Self {
+        Tensor::eye(size, env)
+    }
+
+    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
+        Ok(Tensor::read_npz(path)?)
+    }
+
+    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
+        Ok(Tensor::load_multi(path)?)
+    }
+
+    fn copy_(&mut self, other: &Self) {
+        Tensor::copy_(self, other)
+    }
+
+    fn fill_(&mut self, value: impl Element) {
+        let _ = Tensor::fill_(self, value);
+    }
+
+    fn uniform_(&mut self, low: f64, high: f64) {
+        let _ = Tensor::uniform_(self, low, high);
+    }
+
+    fn reshape(&self, size: &[i64]) -> Self {
+        Tensor::reshape(self, size)
+    }
+    
+    fn view(&self, size: &[i64]) -> Self {
+        Tensor::view(self, size)
+    }
+}

--- a/src/core/tensor_like/tensor_grad.rs
+++ b/src/core/tensor_like/tensor_grad.rs
@@ -1,0 +1,120 @@
+use std::ops::{Deref, DerefMut};
+
+use tch::Tensor;
+
+use super::TensorLike;
+
+pub struct NoGradGuard<'a, T: TensorGrad> {
+    pub tensor: &'a T,
+    pub old_grad: bool
+}
+
+impl<'a, T: TensorGrad> NoGradGuard<'a, T> {
+    pub fn new(tensor: &'a T) -> Self {
+        let old_grad = tensor.requires_grad();
+        tensor.set_requires_grad(false);
+        Self { tensor, old_grad }
+    }
+}
+
+impl<'a, T: TensorGrad> Drop for NoGradGuard<'a, T> {
+    fn drop(&mut self) {
+        self.tensor.set_requires_grad(self.old_grad);
+    }
+}
+
+impl<'a, T: TensorGrad> Deref for NoGradGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.tensor
+    }
+}
+
+pub struct NoGradGuardMut<'a, T: TensorGrad> {
+    pub tensor: &'a mut T,
+    pub old_grad: bool
+}
+
+impl<'a, T: TensorGrad> NoGradGuardMut<'a, T> {
+    pub fn new(tensor: &'a mut T) -> Self {
+        let old_grad = tensor.requires_grad();
+        tensor.set_requires_grad(false);
+        Self { tensor, old_grad }
+    }
+}
+
+impl<'a, T: TensorGrad> Drop for NoGradGuardMut<'a, T> {
+    fn drop(&mut self) {
+        self.tensor.set_requires_grad(self.old_grad);
+    }
+}
+
+impl<'a, T: TensorGrad> Deref for NoGradGuardMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.tensor
+    }
+}
+
+impl<'a, T: TensorGrad> DerefMut for NoGradGuardMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.tensor
+    }
+}
+
+/// A trait for tensor-like objects that can perform backpropagation and compute gradients.
+pub trait TensorGrad: TensorLike {
+    /// Returns the gradient of the tensor.
+    fn grad(&self) -> Self;
+
+    /// Clears the gradient of the tensor.
+    fn zero_grad(&mut self);
+
+    /// Checks if the tensor requires gradient.
+    fn requires_grad(&self) -> bool;
+
+    /// Sets whether the tensor requires gradient.
+    fn set_requires_grad(&self, requires_grad: bool) -> Self;
+
+    /// In-place version of `set_requires_grad`.
+    fn set_requires_grad_(&mut self, requires_grad: bool) {
+        *self = self.set_requires_grad(requires_grad);
+    }
+
+    /// Gets a no-grad guard of the tensor that disables gradient computation.
+    fn no_grad(&self) -> NoGradGuard<Self> {
+        NoGradGuard::new(self)
+    }
+
+    /// Gets a mutable no-grad guard of the tensor that disables gradient computation.
+    fn no_grad_mut(&mut self) -> NoGradGuardMut<Self> {
+        NoGradGuardMut::new(self)
+    }
+
+    /// Do backpropagation on the tensor.
+    fn backward(&self);
+}
+
+impl TensorGrad for Tensor {
+    fn grad(&self) -> Self {
+        self.grad()
+    }
+
+    fn zero_grad(&mut self) {
+        self.zero_grad()
+    }
+
+    fn requires_grad(&self) -> bool {
+        self.requires_grad()
+    }
+
+    fn set_requires_grad(&self, requires_grad: bool) -> Self {
+        self.set_requires_grad(requires_grad)
+    }
+
+    fn backward(&self) {
+        self.backward()
+    }
+}

--- a/src/core/tensor_like/tensor_nn.rs
+++ b/src/core/tensor_like/tensor_nn.rs
@@ -1,0 +1,712 @@
+use std::{borrow::Borrow, f64::consts::PI};
+
+use tch::Tensor;
+
+use crate::core::TensorGrad;
+
+use super::{TensorOps, TensorOpsEx};
+
+pub enum Reduction {
+    None,
+    Mean,
+    Sum,
+}
+
+impl From<Reduction> for tch::Reduction {
+    fn from(reduction: Reduction) -> Self {
+        match reduction {
+            Reduction::None => tch::Reduction::None,
+            Reduction::Mean => tch::Reduction::Mean,
+            Reduction::Sum => tch::Reduction::Sum,
+        }
+    }
+}
+
+/// A trait for tensor-like objects that can perform neural network related operations, such as convolution, pooling, some activation functions and loss functions, etc.
+///
+/// Some of these operations may not strongly require extra low-level performance optimization (using gpu computing, cpu optimization or maybe just some parallel operations), so this trait gives a default implementation for them. But you can still override them if you want to.
+pub trait TensorNN: TensorOps + TensorGrad {
+    /// Computes the 1D convolution of the input tensor with the kernel.
+    ///
+    /// The input tensor should be a 3D tensor of shape `(batch_size, channels, length)`.
+    ///
+    /// The kernel should be a 3D tensor of shape `(out_channels, channels / groups, kernel_size)`.
+    ///
+    /// The `bias` parameter is optional, and should be a 1D tensor of shape (out_channels).
+    ///
+    /// The output tensor will be a 3D tensor of shape (batch_size, out_channels, out_length), or a 4D tensor of shape (batch_size, out_channels, out_height, out_width).
+    ///
+    /// The `stride` parameter specifies the stride of the convolution.
+    ///
+    /// The `padding` parameter specifies the padding of the convolution.
+    ///
+    /// The `dilation` parameter specifies the dilation of the convolution.
+    ///
+    /// The `groups` parameter specifies the number of blocked connections from input channels to output channels.
+    fn conv1d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self;
+
+    /// Computes the 2D convolution of the input tensor with the kernel.
+    ///
+    /// The input tensor should be a 4D tensor of shape `(batch_size, channels, height, width)`.
+    ///
+    /// The kernel should be a 4D tensor of shape `(out_channels, channels / groups, kernel_height, kernel_width)`.
+    ///
+    /// The `bias` parameter is optional, and should be a 1D tensor of shape (out_channels).
+    ///
+    /// The output tensor will be a 4D tensor of shape (batch_size, out_channels, out_height, out_width).
+    ///
+    /// The `stride` parameter specifies the stride of the convolution.
+    ///
+    /// The `padding` parameter specifies the padding of the convolution.
+    ///
+    /// The `dilation` parameter specifies the dilation of the convolution.
+    ///
+    /// The `groups` parameter specifies the number of blocked connections from input channels to output channels.
+    fn conv2d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self;
+
+    /// Computes the 3D convolution of the input tensor with the kernel.
+    ///
+    /// The input tensor should be a 5D tensor of shape `(batch_size, channels, depth, height, width)`.
+    ///
+    /// The kernel should be a 5D tensor of shape `(out_channels, channels / groups, kernel_depth, kernel_height, kernel_width)`.
+    ///
+    /// The `bias` parameter is optional, and should be a 1D tensor of shape (out_channels).
+    ///
+    /// The output tensor will be a 5D tensor of shape (batch_size, out_channels, out_depth, out_height, out_width).
+    ///
+    /// The `stride` parameter specifies the stride of the convolution.
+    ///
+    /// The `padding` parameter specifies the padding of the convolution.
+    ///
+    /// The `dilation` parameter specifies the dilation of the convolution.
+    ///
+    /// The `groups` parameter specifies the number of blocked connections from input channels to output channels.
+    fn conv3d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self;
+
+    /// Computes the 1D max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 3D tensor of shape `(batch_size, channels, length)`.
+    ///
+    /// The output tensor will be a 3D tensor of shape (batch_size, channels, out_length).
+    ///
+    /// The `kernel_size` parameter specifies the size of the max pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the max pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the max pooling.
+    ///
+    /// The `dilation` parameter specifies the dilation of the max pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    fn max_pool1d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self;
+
+    /// Computes the 2D max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 4D tensor of shape `(batch_size, channels, height, width)`.
+    ///
+    /// The output tensor will be a 4D tensor of shape (batch_size, channels, out_height, out_width).
+    ///
+    /// The `kernel_size` parameter specifies the size of the max pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the max pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the max pooling.
+    ///
+    /// The `dilation` parameter specifies the dilation of the max pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    fn max_pool2d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self;
+
+    /// Computes the 3D max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 5D tensor of shape `(batch_size, channels, depth, height, width)`.
+    ///
+    /// The output tensor will be a 5D tensor of shape (batch_size, channels, out_depth, out_height, out_width).
+    ///
+    /// The `kernel_size` parameter specifies the size of the max pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the max pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the max pooling.
+    ///
+    /// The `dilation` parameter specifies the dilation of the max pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    fn max_pool3d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self;
+
+    /// Computes the 1D average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 3D tensor of shape `(batch_size, channels, length)`.
+    ///
+    /// The output tensor will be a 3D tensor of shape (batch_size, channels, out_length).
+    ///
+    /// The `kernel_size` parameter specifies the size of the average pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the average pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the average pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    ///
+    /// The `count_include_pad` parameter specifies whether to include padding in the average computation.
+    fn avg_pool1d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+    ) -> Self;
+
+    /// Computes the 2D average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 4D tensor of shape `(batch_size, channels, height, width)`.
+    ///
+    /// The output tensor will be a 4D tensor of shape (batch_size, channels, out_height, out_width).
+    ///
+    /// The `kernel_size` parameter specifies the size of the average pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the average pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the average pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    ///
+    /// The `count_include_pad` parameter specifies whether to include padding in the average computation.
+    ///
+    /// The `divisor_override` parameter specifies the divisor to use in the average computation.
+    fn avg_pool2d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+        divisor_override: Option<i64>,
+    ) -> Self;
+
+    /// Computes the 3D average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 5D tensor of shape `(batch_size, channels, depth, height, width)`.
+    ///
+    /// The output tensor will be a 5D tensor of shape (batch_size, channels, out_depth, out_height, out_width).
+    ///
+    /// The `kernel_size` parameter specifies the size of the average pooling kernel.
+    ///
+    /// The `stride` parameter specifies the stride of the average pooling.
+    ///
+    /// The `padding` parameter specifies the padding of the average pooling.
+    ///
+    /// The `ceil_mode` parameter specifies whether to use ceil or floor to compute the output shape.
+    ///
+    /// The `count_include_pad` parameter specifies whether to include padding in the average computation.
+    ///
+    /// The `divisor_override` parameter specifies the divisor to use in the average computation.
+    fn avg_pool3d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+        divisor_override: Option<i64>,
+    ) -> Self;
+
+    /// Computes the 1D adaptive max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 3D tensor of shape `(batch_size, channels, length)`.
+    ///
+    /// The output tensor will be a 3D tensor of shape (batch_size, channels, output_size).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the length dimension.
+    fn adaptive_max_pool1d(&self, output_size: &[i64]) -> (Self, Self);
+
+    /// Computes the 2D adaptive max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 4D tensor of shape `(batch_size, channels, height, width)`.
+    ///
+    /// The output tensor will be a 4D tensor of shape (batch_size, channels, output_size[0], output_size[1]).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the height and width dimensions.
+    fn adaptive_max_pool2d(&self, output_size: &[i64]) -> (Self, Self);
+
+    /// Computes the 3D adaptive max pooling of the input tensor.
+    ///
+    /// The input tensor should be a 5D tensor of shape `(batch_size, channels, depth, height, width)`.
+    ///
+    /// The output tensor will be a 5D tensor of shape (batch_size, channels, output_size[0], output_size[1], output_size[2]).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the depth, height and width dimensions.
+    fn adaptive_max_pool3d(&self, output_size: &[i64]) -> (Self, Self);
+
+    /// Computes the 1D adaptive average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 3D tensor of shape `(batch_size, channels, length)`.
+    ///
+    /// The output tensor will be a 3D tensor of shape (batch_size, channels, output_size).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the length dimension.
+    fn adaptive_avg_pool1d(&self, output_size: &[i64]) -> Self;
+
+    /// Computes the 2D adaptive average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 4D tensor of shape `(batch_size, channels, height, width)`.
+    ///
+    /// The output tensor will be a 4D tensor of shape (batch_size, channels, output_size[0], output_size[1]).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the height and width dimensions.
+    fn adaptive_avg_pool2d(&self, output_size: &[i64]) -> Self;
+
+    /// Computes the 3D adaptive average pooling of the input tensor.
+    ///
+    /// The input tensor should be a 5D tensor of shape `(batch_size, channels, depth, height, width)`.
+    ///
+    /// The output tensor will be a 5D tensor of shape (batch_size, channels, output_size[0], output_size[1], output_size[2]).
+    ///
+    /// The `output_size` parameter specifies the size of the output tensor in the depth, height and width dimensions.
+    fn adaptive_avg_pool3d(&self, output_size: &[i64]) -> Self;
+
+    /// Computes ReLU of the input tensor.
+    fn relu(&self) -> Self {
+        self.r#where(&self.gt_scalar(0.0), &Self::zeros(&[], self.env()))
+    }
+
+    /// Computes LeakyReLU of the input tensor.
+    fn leaky_relu(&self, negative_slope: f64) -> Self {
+        self.r#where(&self.gt_scalar(0.0), self * negative_slope)
+    }
+
+    /// Computes GELU of the input tensor.
+    fn gelu(&self) -> Self {
+        let z = (self + &self.pow_scalar(3) * 0.044715) * (2.0f64 / PI).sqrt();
+        0.5 * self * (1 + z.tanh())
+    }
+
+    /// Computes softmax of the input tensor.
+    fn softmax(&self, dim: i64) -> Self {
+        let exp = self.exp();
+        let sum = exp.sum_dim(&[dim], true);
+        exp / sum
+    }
+
+    /// Computes log softmax of the input tensor.
+    fn log_softmax(&self, dim: i64) -> Self {
+        self.softmax(dim).log()
+    }
+
+    /// Computes cross entropy loss between the input tensor and the target tensor
+    ///
+    /// The input tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    /// The target tensor should be a 1D tensor of shape `(batch_size)`.
+    ///
+    /// The output tensor will be a 1D tensor of shape `(batch_size)`.
+    ///
+    /// The `reduction` parameter specifies the reduction to apply to the output:
+    /// - `Reduction::None` means no reduction will be applied.
+    /// - `Reduction::Mean` means the output will be the mean of the output over the batch.
+    /// - `Reduction::Sum` means the output will be the sum of the output over the batch.
+    ///
+    /// The `ignore_index` parameter specifies the index to ignore when computing the loss.
+    ///
+    /// The `weight` parameter specifies the weight to apply to each class.
+    ///
+    /// The `label_smoothing` parameter specifies the amount of label smoothing to apply.
+    fn cross_entropy_loss<T: Borrow<Self>, U: Borrow<Self>>(
+        &self,
+        target: T,
+        weight: Option<U>,
+        reduction: Reduction,
+        ignore_index: i64,
+        label_smoothing: f64,
+    ) -> Self;
+
+    /// Computes binary cross entropy loss between the input tensor and the target tensor
+    ///
+    /// The input tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    /// The target tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    ///
+    /// The output tensor will be a 1D tensor of shape `(batch_size)`.
+    ///
+    /// The `reduction` parameter specifies the reduction to apply to the output:
+    /// - `Reduction::None` means no reduction will be applied.
+    /// - `Reduction::Mean` means the output will be the mean of the output over the batch.
+    /// - `Reduction::Sum` means the output will be the sum of the output over the batch.
+    ///
+    /// The `weight` parameter specifies the weight to apply to each class.
+    fn binary_cross_entropy_loss<T: Borrow<Self>, U: Borrow<Self>, V: Borrow<Self>>(
+        &self,
+        target: T,
+        weight: Option<U>,
+        reduction: Reduction,
+    ) -> Self;
+
+    /// Computes mean squared error loss between the input tensor and the target tensor
+    ///
+    /// The input tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    /// The target tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    ///
+    /// The output tensor will be a 1D tensor of shape `(batch_size)`.
+    ///
+    /// The `reduction` parameter specifies the reduction to apply to the output:
+    /// - `Reduction::None` means no reduction will be applied.
+    /// - `Reduction::Mean` means the output will be the mean of the output over the batch.
+    /// - `Reduction::Sum` means the output will be the sum of the output over the batch.
+    fn mse_loss<T: Borrow<Self>, U: Borrow<Self>>(&self, target: T, reduction: Reduction) -> Self;
+
+    /// During training, randomly zeroes some of the elements of the input tensor with probability `p`.
+    ///
+    /// The input tensor should be a 2D tensor of shape `(batch_size, num_classes)`.
+    ///
+    /// The output tensor will be a 2D tensor of shape `(batch_size, num_classes)`.
+    ///
+    /// The `p` parameter specifies the probability of an element to be zeroed.
+    fn dropout(&self, p: f64, train: bool) -> Self;
+
+    /// Computes the batch norm of the input tensor.
+    ///
+    /// The input tensor should be a tensor of shape `(batch_size, num_classes, *)`, where `*` means any number of additional dimensions.
+    ///
+    /// The output tensor will be a tensor of shape `(batch_size, num_classes, *)`, where `*` equals the additional dimensions of the input tensor.
+    ///
+    /// The `weight` parameter specifies the weight to apply to the normalized input.
+    ///
+    /// The `bias` parameter specifies the bias to apply to the normalized input.
+    ///
+    /// The `running_mean` parameter specifies the running mean of the input.
+    ///
+    /// The `running_var` parameter specifies the running variance of the input.
+    ///
+    /// The `training` parameter specifies whether the input is in training mode.
+    ///
+    /// The `momentum` parameter specifies the momentum to use for the running mean and variance.
+    ///
+    /// The `eps` parameter specifies the epsilon to use for the running mean and variance.
+    ///
+    /// The `cudnn_enabled` parameter specifies whether to use cuDNN for the batch norm.
+    fn batch_norm<T: Borrow<Self>, U: Borrow<Self>, V: Borrow<Self>, W: Borrow<Self>>(
+        &self,
+        weight: Option<T>,
+        bias: Option<U>,
+        running_mean: Option<V>,
+        running_var: Option<W>,
+        training: bool,
+        momentum: f64,
+        eps: f64,
+        cudnn_enabled: bool,
+    ) -> Self;
+
+    /// Computes the layer norm of the input tensor.
+    ///
+    /// The input tensor should be a tensor of shape `(batch_size, num_classes, *)`, where `*` means any number of additional dimensions.
+    ///
+    /// The output tensor will be a tensor of shape `(batch_size, num_classes, *)`, where `*` equals the additional dimensions of the input tensor.
+    ///
+    /// The `normalized_shape` parameter specifies the shape of the normalized input.
+    ///
+    /// The `weight` parameter specifies the weight to apply to the normalized input.
+    ///
+    /// The `bias` parameter specifies the bias to apply to the normalized input.
+    ///
+    /// The `eps` parameter specifies the epsilon to use for the normalization.
+    ///
+    /// The `cudnn_enabled` parameter specifies whether to use cuDNN for the layer norm.
+    fn layer_norm<T: Borrow<Self>, U: Borrow<Self>>(
+        &self,
+        normalized_shape: &[i64],
+        weight: Option<T>,
+        bias: Option<U>,
+        eps: f64,
+        cudnn_enabled: bool,
+    ) -> Self;
+}
+
+default impl<T: TensorOpsEx + TensorGrad> TensorNN for T {
+    /// A default implementation of `dropout` that uses `bernoulli`.
+    fn dropout(&self, p: f64, train: bool) -> Self {
+        if train {
+            let mask = self.ones_like() * (1.0 - p);
+            self * mask.bernoulli()
+        } else {
+            self.copy()
+        }
+    }
+}
+
+impl TensorNN for Tensor {
+    fn conv1d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self {
+        self.conv1d(kernel.borrow(), bias, stride, padding, dilation, groups)
+    }
+
+    fn conv2d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self {
+        self.conv2d(kernel.borrow(), bias, stride, padding, dilation, groups)
+    }
+
+    fn conv3d(
+        &self,
+        kernel: impl Borrow<Self>,
+        bias: Option<impl Borrow<Self>>,
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        groups: i64,
+    ) -> Self {
+        self.conv3d(kernel.borrow(), bias, stride, padding, dilation, groups)
+    }
+
+    fn max_pool1d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self {
+        self.max_pool1d(kernel_size, stride, padding, dilation, ceil_mode)
+    }
+
+    fn max_pool2d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self {
+        self.max_pool2d(kernel_size, stride, padding, dilation, ceil_mode)
+    }
+
+    fn max_pool3d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        dilation: &[i64],
+        ceil_mode: bool,
+    ) -> Self {
+        self.max_pool3d(kernel_size, stride, padding, dilation, ceil_mode)
+    }
+
+    fn avg_pool1d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+    ) -> Self {
+        self.avg_pool1d(kernel_size, stride, padding, ceil_mode, count_include_pad)
+    }
+
+    fn avg_pool2d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+        divisor_override: Option<i64>,
+    ) -> Self {
+        self.avg_pool2d(
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    }
+
+    fn avg_pool3d(
+        &self,
+        kernel_size: &[i64],
+        stride: &[i64],
+        padding: &[i64],
+        ceil_mode: bool,
+        count_include_pad: bool,
+        divisor_override: Option<i64>,
+    ) -> Self {
+        self.avg_pool3d(
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    }
+
+    fn adaptive_max_pool1d(&self, output_size: &[i64]) -> (Self, Self) {
+        self.adaptive_max_pool1d(output_size)
+    }
+
+    fn adaptive_max_pool2d(&self, output_size: &[i64]) -> (Self, Self) {
+        self.adaptive_max_pool2d(output_size)
+    }
+
+    fn adaptive_max_pool3d(&self, output_size: &[i64]) -> (Self, Self) {
+        self.adaptive_max_pool3d(output_size)
+    }
+
+    fn adaptive_avg_pool1d(&self, output_size: &[i64]) -> Self {
+        self.adaptive_avg_pool1d(output_size)
+    }
+
+    fn adaptive_avg_pool2d(&self, output_size: &[i64]) -> Self {
+        self.adaptive_avg_pool2d(output_size)
+    }
+
+    fn adaptive_avg_pool3d(&self, output_size: &[i64]) -> Self {
+        self.adaptive_avg_pool3d(output_size)
+    }
+
+    fn relu(&self) -> Self {
+        self.relu()
+    }
+
+    fn gelu(&self) -> Self {
+        self.gelu("none")
+    }
+
+    fn softmax(&self, dim: i64) -> Self {
+        self.softmax(dim, self.kind())
+    }
+
+    fn log_softmax(&self, dim: i64) -> Self {
+        self.log_softmax(dim, self.kind())
+    }
+
+    fn cross_entropy_loss<T: Borrow<Self>, U: Borrow<Self>>(
+        &self,
+        target: T,
+        weight: Option<U>,
+        reduction: Reduction,
+        ignore_index: i64,
+        label_smoothing: f64,
+    ) -> Self {
+        self.cross_entropy_loss(
+            target.borrow(),
+            weight,
+            reduction.into(),
+            ignore_index,
+            label_smoothing,
+        )
+    }
+
+    fn binary_cross_entropy_loss<T: Borrow<Self>, U: Borrow<Self>, V: Borrow<Self>>(
+        &self,
+        target: T,
+        weight: Option<U>,
+        reduction: Reduction,
+    ) -> Self {
+        self.binary_cross_entropy(target.borrow(), weight, reduction.into())
+    }
+
+    fn mse_loss<T: Borrow<Self>, U: Borrow<Self>>(&self, target: T, reduction: Reduction) -> Self {
+        self.mse_loss(target.borrow(), reduction.into())
+    }
+
+    fn dropout(&self, p: f64, train: bool) -> Self {
+        self.dropout(p, train)
+    }
+
+    fn batch_norm<T: Borrow<Self>, U: Borrow<Self>, V: Borrow<Self>, W: Borrow<Self>>(
+        &self,
+        weight: Option<T>,
+        bias: Option<U>,
+        running_mean: Option<V>,
+        running_var: Option<W>,
+        training: bool,
+        momentum: f64,
+        eps: f64,
+        cudnn_enabled: bool,
+    ) -> Self {
+        self.batch_norm(
+            weight.as_ref().map(|w| w.borrow()),
+            bias.as_ref().map(|w| w.borrow()),
+            running_mean.as_ref().map(|w| w.borrow()),
+            running_var.as_ref().map(|w| w.borrow()),
+            training,
+            momentum,
+            eps,
+            cudnn_enabled,
+        )
+    }
+
+    fn layer_norm<T: Borrow<Self>, U: Borrow<Self>>(
+        &self,
+        normalized_shape: &[i64],
+        weight: Option<T>,
+        bias: Option<U>,
+        eps: f64,
+        cudnn_enabled: bool,
+    ) -> Self {
+        self.layer_norm(
+            normalized_shape,
+            weight.as_ref().map(|w| w.borrow()),
+            bias.as_ref().map(|w| w.borrow()),
+            eps,
+            cudnn_enabled,
+        )
+    }
+}

--- a/src/core/tensor_like/tensor_ops.rs
+++ b/src/core/tensor_like/tensor_ops.rs
@@ -1,11 +1,11 @@
 use std::{
     borrow::Borrow,
-    fmt::Debug,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
-    path::Path,
 };
+use tch::Tensor;
 
-use tch::{Device, Kind, Tensor, Scalar};
+use super::{TensorLike, Element};
+
 
 pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
 pub trait AddScalar<T> = Add<f64, Output = T> + Add<i64, Output = T> where T: Sized;
@@ -93,123 +93,6 @@ pub trait DivAssignTrait = DivAssign<Self>
 
 pub trait NegTrait = Neg<Output = Self> + for<'a> Neg<Output = Self> + Sized;
 
-pub trait Element: Clone + tch::kind::Element + Into<Scalar> {}
-
-impl Element for u8 {}
-impl Element for i8 {}
-impl Element for i16 {}
-impl Element for i32 {}
-impl Element for i64 {}
-impl Element for f32 {}
-impl Element for f64 {}
-impl Element for bool {}
-
-/// A trait for a tensor-like object.
-///
-/// A tensor-like object should have the following properties:
-/// - It should be associated with some env variable, which for example may be used to determine the device and data type of the tensor-like object, and a size indicating the length of each dimension.
-/// - It should be able to be constructed with some factors, or other tensor-like objects.
-/// - It should also be able to perform some other operations, such as reshaping, transposing, and slicing.
-///
-/// Of course, a real tensor-like object should also be able to perform some tensor operations, such as arithmetic operations, matrix multiplication, gradient calculation, and so on. However, this trait just focuses on the properties of tensor-like objects, and does not require further functions.
-pub trait TensorLike: PartialEq<Self> + AsRef<Self> + Debug + Default {
-    /// The type of the env variable.
-    type Env: Default;
-
-    /// Get the env variable.
-    fn env(&self) -> Self::Env;
-
-    /// Get the size of the tensor-like object.
-    fn size(&self) -> Vec<i64>;
-
-    /// Create a tensor-like object from a slice.
-    fn of_slice<T: Element>(data: &[T]) -> Self;
-
-    /// Create a 2-D tensor-like object from a slice of slices.
-    fn of_slice2<T: Element, U: AsRef<[T]>>(v: &[U]) -> Self
-    {
-        let inner: Vec<Self> = v.iter().map(|v| Self::of_slice(v.as_ref())).collect();
-        Self::stack(&inner, 0)
-    }
-
-    /// Stack a list of tensor-like objects into a tensor-like object.
-    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
-
-    /// Concatenate a list of tensor-like objects into a tensor-like object.
-    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self;
-
-    /// Create a tensor-like object filled with zeros.
-    fn zeros(size: &[i64], env: Self::Env) -> Self;
-
-    /// Create a tensor-like object filled with ones.
-    fn ones(size: &[i64], env: Self::Env) -> Self;
-
-    /// Create a tensor-like object filled with uninitialized values.
-    fn empty(size: &[i64], env: Self::Env) -> Self;
-
-    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with zeros.
-    fn zeros_like(&self) -> Self {
-        Self::zeros(&self.size(), self.env())
-    }
-
-    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with ones.
-    fn ones_like(&self) -> Self {
-        Self::ones(&self.size(), self.env())
-    }
-
-    /// Create a tensor-like object with the same size and env as the given tensor-like object, filled with uninitialized values.
-    fn empty_like(&self) -> Self {
-        Self::empty(&self.size(), self.env())
-    }
-
-    /// Create a 2-D tensor-like object with ones on the diagonal and zeros elsewhere.
-    fn eye(size: i64, env: Self::Env) -> Self;
-
-    /// Read named tensor-like objects from a .npz file.
-    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
-
-    /// Read named tensor-like objects from a .ot file.
-    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error>;
-
-    /// Copy the tensor-like object to self.
-    fn copy_(&mut self, other: &Self);
-
-    /// Copy to a new tensor-like object.
-    fn copy(&self) -> Self {
-        let mut result = self.empty_like();
-        result.copy_(self);
-        result
-    }
-
-    /// Fill the tensor-like object with given value.
-    fn fill_(&mut self, value: impl Element);
-
-    /// Uniformly fill the tensor-like object with values in the given range.
-    fn uniform_(&mut self, low: f64, high: f64);
-
-    /// Initialize the tensor-like object with values from kaiming uniform distribution.
-    fn kaiming_uniform_(&mut self) {
-        let fan_in: i64 = self.size().iter().skip(1).product();
-        let bound = (1.0 / fan_in as f64).sqrt();
-        self.uniform_(-bound, bound);
-    }
-
-    /// Reshape the tensor-like object as the given size.
-    fn reshape(&self, size: &[i64]) -> Self;
-
-    /// Reshape the tensor-like object as the same size as the given tensor-like object.
-    fn reshape_as(&self, other: &Self) -> Self {
-        self.reshape(&other.size())
-    }
-
-    /// View the tensor-like object as the given size.
-    fn view(&self, size: &[i64]) -> Self;
-
-    /// View the tensor-like object as the same size as the given tensor-like object.
-    fn view_as(&self, other: &Self) -> Self {
-        self.view(&other.size())
-    }
-}
 
 /// A trait for a tensor-like object that can perform basic algebraic operations, including arithmetic operations, matrix multiplication, trigonometric functions, and so on.
 ///
@@ -384,73 +267,7 @@ pub trait TensorOps:
     fn ne_scalar<S: Element>(&self, other: S) -> Self;
 }
 
-impl TensorLike for Tensor {
-    type Env = (Kind, Device);
 
-    fn env(&self) -> Self::Env {
-        (self.kind(), self.device())
-    }
-
-    fn size(&self) -> Vec<i64> {
-        self.size().iter().map(|x| *x as i64).collect()
-    }
-
-    fn of_slice<T: Element>(data: &[T]) -> Self {
-        Tensor::of_slice(data)
-    }
-
-    fn stack<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
-        Tensor::stack(tensors, dim)
-    }
-
-    fn cat<T: Borrow<Self>>(tensors: &[T], dim: i64) -> Self {
-        Tensor::cat(tensors, dim)
-    }
-
-    fn zeros(size: &[i64], env: Self::Env) -> Self {
-        Tensor::zeros(size, env)
-    }
-
-    fn ones(size: &[i64], env: Self::Env) -> Self {
-        Tensor::ones(size, env)
-    }
-
-    fn empty(size: &[i64], env: Self::Env) -> Self {
-        Tensor::empty(size, env)
-    }
-
-    fn eye(size: i64, env: Self::Env) -> Self {
-        Tensor::eye(size, env)
-    }
-
-    fn read_npz<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
-        Ok(Tensor::read_npz(path)?)
-    }
-
-    fn read_ot<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, anyhow::Error> {
-        Ok(Tensor::load_multi(path)?)
-    }
-
-    fn copy_(&mut self, other: &Self) {
-        Tensor::copy_(self, other)
-    }
-
-    fn fill_(&mut self, value: impl Element) {
-        let _ = Tensor::fill_(self, value);
-    }
-
-    fn uniform_(&mut self, low: f64, high: f64) {
-        let _ = Tensor::uniform_(self, low, high);
-    }
-
-    fn reshape(&self, size: &[i64]) -> Self {
-        Tensor::reshape(self, size)
-    }
-    
-    fn view(&self, size: &[i64]) -> Self {
-        Tensor::view(self, size)
-    }
-}
 
 impl TensorOps for Tensor {
     fn sum(&self) -> Self {

--- a/src/core/tensor_like/tensor_ops.rs
+++ b/src/core/tensor_like/tensor_ops.rs
@@ -6,6 +6,14 @@ use tch::Tensor;
 
 use super::{TensorLike, Element};
 
+// Trait bounds for tensor-like objects that can perform arithmetic operations.
+// 
+// These bounds include:
+// - `Tensor` and `Tensor`, `Tensor` and `&Tensor`, `&Tensor` and `Tensor`, `&Tensor` and `&Tensor`, `Tensor` and `Scalar`, `Scalar` and `Tensor`, `&Tensor` and `Scalar`, `Scalar` and `&Tensor` can be added, subtracted, multiplied, and divided.
+// - `Tensor` and `Tensor`, `Tensor` and `&Tensor`, `Tensor` and `Scalar` can be added, subtracted, multiplied, and divided in place.
+// - `Tensor` can be negated.
+// 
+// Scalar types include `i32`, `i64`, `f32`, `f64`.
 
 pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
 pub trait AddScalar<T> = Add<f64, Output = T> + Add<i64, Output = T> where T: Sized;

--- a/src/core/tensor_like/tensor_ops.rs
+++ b/src/core/tensor_like/tensor_ops.rs
@@ -4,15 +4,15 @@ use std::{
 };
 use tch::Tensor;
 
-use super::{TensorLike, Element};
+use super::{Element, TensorLike};
 
 // Trait bounds for tensor-like objects that can perform arithmetic operations.
-// 
+//
 // These bounds include:
 // - `Tensor` and `Tensor`, `Tensor` and `&Tensor`, `&Tensor` and `Tensor`, `&Tensor` and `&Tensor`, `Tensor` and `Scalar`, `Scalar` and `Tensor`, `&Tensor` and `Scalar`, `Scalar` and `&Tensor` can be added, subtracted, multiplied, and divided.
 // - `Tensor` and `Tensor`, `Tensor` and `&Tensor`, `Tensor` and `Scalar` can be added, subtracted, multiplied, and divided in place.
 // - `Tensor` can be negated.
-// 
+//
 // Scalar types include `i32`, `i64`, `f32`, `f64`.
 
 pub trait AddSelf<T> = Add<T, Output = T> + for<'a> Add<&'a T, Output = T> where T: Sized;
@@ -101,7 +101,6 @@ pub trait DivAssignTrait = DivAssign<Self>
 
 pub trait NegTrait = Neg<Output = Self> + for<'a> Neg<Output = Self> + Sized;
 
-
 /// A trait for a tensor-like object that can perform basic algebraic operations, including arithmetic operations, matrix multiplication, trigonometric functions, and so on.
 ///
 /// Some more advanced operations, such as gradient calculation, convolution, and so on, are not included in this trait.
@@ -121,7 +120,7 @@ pub trait TensorOps:
     fn sum(&self) -> Self;
 
     /// Calculate the sum of each row of the tensor-like object in the given dimensions `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
     fn sum_dim(&self, dim: &[i64], keep_dim: bool) -> Self;
 
@@ -129,7 +128,7 @@ pub trait TensorOps:
     fn mean(&self) -> Self;
 
     /// Calculate the mean of each row of the tensor-like object in the given dimensions `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
     fn mean_dim(&self, dim: &[i64], keep_dim: bool) -> Self;
 
@@ -137,9 +136,9 @@ pub trait TensorOps:
     fn max(&self) -> Self;
 
     /// Calculate the maximum of each row of the tensor-like object in the given dimension `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
-    /// 
+    ///
     /// Returns a tuple of the maximum value and the index of the maximum value.
     fn max_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self);
 
@@ -147,9 +146,9 @@ pub trait TensorOps:
     fn min(&self) -> Self;
 
     /// Calculate the minimum of each row of the tensor-like object in the given dimension `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
-    /// 
+    ///
     /// Returns a tuple of the minimum value and the index of the minimum value.
     fn min_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self);
 
@@ -157,7 +156,7 @@ pub trait TensorOps:
     fn argmax(&self) -> Self;
 
     /// Calculate the argmax of each row of the tensor-like object in the given dimension `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
     fn argmax_dim(&self, dim: i64, keep_dim: bool) -> Self;
 
@@ -165,7 +164,7 @@ pub trait TensorOps:
     fn argmin(&self) -> Self;
 
     /// Calculate the argmin of each row of the tensor-like object in the given dimension `dim`.
-    /// 
+    ///
     /// If `keepdim` is true, the dimensions of the tensor-like object will be kept.
     fn argmin_dim(&self, dim: i64, keep_dim: bool) -> Self;
 
@@ -180,6 +179,12 @@ pub trait TensorOps:
 
     /// Calculate the element-wise square of the tensor-like object.
     fn square(&self) -> Self;
+
+    /// Calculate the element-wise power of the tensor-like object.
+    fn pow<T: Borrow<Self>>(&self, exponent: T) -> Self;
+
+    /// Calculate the element-wise power of the tensor-like object with a scalar.
+    fn pow_scalar<S: Element>(&self, exponent: S) -> Self;
 
     /// Calculate the element-wise square root of the tensor-like object.
     fn sqrt(&self) -> Self;
@@ -227,7 +232,7 @@ pub trait TensorOps:
     fn atanh(&self) -> Self;
 
     /// Compute the element-wise less-than comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn lt<T: Borrow<Self>>(&self, other: T) -> Self;
 
@@ -235,7 +240,7 @@ pub trait TensorOps:
     fn lt_scalar<S: Element>(&self, other: S) -> Self;
 
     /// Compute the element-wise less-than-or-equal comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn le<T: Borrow<Self>>(&self, other: T) -> Self;
 
@@ -243,7 +248,7 @@ pub trait TensorOps:
     fn le_scalar<S: Element>(&self, other: S) -> Self;
 
     /// Compute the element-wise greater-than comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn gt<T: Borrow<Self>>(&self, other: T) -> Self;
 
@@ -251,7 +256,7 @@ pub trait TensorOps:
     fn gt_scalar<S: Element>(&self, other: S) -> Self;
 
     /// Compute the element-wise greater-than-or-equal comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn ge<T: Borrow<Self>>(&self, other: T) -> Self;
 
@@ -259,7 +264,7 @@ pub trait TensorOps:
     fn ge_scalar<S: Element>(&self, other: S) -> Self;
 
     /// Compute the element-wise equality comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn eq<T: Borrow<Self>>(&self, other: T) -> Self;
 
@@ -267,186 +272,229 @@ pub trait TensorOps:
     fn eq_scalar<S: Element>(&self, other: S) -> Self;
 
     /// Compute the element-wise inequality comparison of the tensor-like object and the given tensor-like object.
-    /// 
+    ///
     /// The given tensor-like object must have a shape that is broadcastable to the shape of the tensor-like object.
     fn ne<T: Borrow<Self>>(&self, other: T) -> Self;
 
     /// Compute the element-wise inequality comparison of the tensor-like object and the given scalar.
     fn ne_scalar<S: Element>(&self, other: S) -> Self;
+
+    /// Return a tensor of elements selected from either `self` or `other`, depending on `condition`.
+    fn r#where<T: Borrow<Self>, U: Borrow<Self>>(&self, condition: T, other: U) -> Self;
+
+    /// Gather slices from the tensor-like object along the given axis.
+    fn gather<T: Borrow<Self>>(&self, dim: i64, indices: T) -> Self;
+
+    /// Returns a tensor-like object where all dimensions of size 1 are removed.
+    fn squeeze(&self) -> Self;
+
+    /// Returns a tensor-like object where a dimension along the given axis is removed if its size is 1.
+    fn squeeze_dim(&self, dim: i64) -> Self;
+
+    /// Returns a tensor-like object with a dimension of size one inserted at the specified position.
+    ///
+    /// The dimension index `axis` starts at zero; if you specify a negative number, it is counted backward from the end.
+    fn unsqueeze(&self, dim: i64) -> Self;
 }
-
-
 
 impl TensorOps for Tensor {
     fn sum(&self) -> Self {
-        Tensor::sum(self, self.kind())
+        self.sum(self.kind())
     }
 
     fn sum_dim(&self, dim: &[i64], keep_dim: bool) -> Self {
-        Tensor::sum_dim_intlist(self, dim, keep_dim, self.kind())
+        self.sum_dim_intlist(dim, keep_dim, self.kind())
     }
 
     fn mean(&self) -> Self {
-        Tensor::mean(self, self.kind())
+        self.mean(self.kind())
     }
 
     fn mean_dim(&self, dim: &[i64], keep_dim: bool) -> Self {
-        Tensor::mean_dim(self, dim, keep_dim, self.kind())
+        self.mean_dim(dim, keep_dim, self.kind())
     }
 
     fn max(&self) -> Self {
-        Tensor::max(self)
+        self.max()
     }
 
     fn max_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self) {
-        Tensor::max_dim(self, dim, keep_dim)
+        self.max_dim(dim, keep_dim)
     }
 
     fn min(&self) -> Self {
-        Tensor::min(self)
+        self.min()
     }
 
     fn min_dim(&self, dim: i64, keep_dim: bool) -> (Self, Self) {
-        Tensor::min_dim(self, dim, keep_dim)
+        self.min_dim(dim, keep_dim)
     }
 
     fn argmax(&self) -> Self {
-        Tensor::argmax(self, None, false)
+        self.argmax(None, false)
     }
 
     fn argmax_dim(&self, dim: i64, keep_dim: bool) -> Self {
-        Tensor::argmax(self, Some(dim), keep_dim)
+        self.argmax(Some(dim), keep_dim)
     }
 
     fn argmin(&self) -> Self {
-        Tensor::argmin(self, None, false)
+        self.argmin(None, false)
     }
 
     fn argmin_dim(&self, dim: i64, keep_dim: bool) -> Self {
-        Tensor::argmin(self, Some(dim), keep_dim)
+        self.argmin(Some(dim), keep_dim)
     }
 
     fn transpose(&self, dim0: i64, dim1: i64) -> Self {
-        Tensor::transpose(self, dim0, dim1)
+        self.transpose(dim0, dim1)
     }
 
     fn matmul<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::matmul(self, other.borrow())
+        self.matmul(other.borrow())
     }
-    
+
     fn abs(&self) -> Self {
-        Tensor::abs(self)
+        self.abs()
     }
 
     fn square(&self) -> Self {
-        Tensor::square(self)
+        self.square()
+    }
+
+    fn pow<T: Borrow<Self>>(&self, exponent: T) -> Self {
+        self.pow(exponent.borrow())
+    }
+
+    fn pow_scalar<S: Element>(&self, exponent: S) -> Self {
+        self.pow_tensor_scalar(exponent)
     }
 
     fn sqrt(&self) -> Self {
-        Tensor::sqrt(self)
+        self.sqrt()
     }
 
     fn exp(&self) -> Self {
-        Tensor::exp(self)
+        self.exp()
     }
 
     fn log(&self) -> Self {
-        Tensor::log(self)
+        self.log()
     }
 
     fn sin(&self) -> Self {
-        Tensor::sin(self)
+        self.sin()
     }
 
     fn cos(&self) -> Self {
-        Tensor::cos(self)
+        self.cos()
     }
 
     fn tan(&self) -> Self {
-        Tensor::tan(self)
+        self.tan()
     }
 
     fn asin(&self) -> Self {
-        Tensor::asin(self)
+        self.asin()
     }
 
     fn acos(&self) -> Self {
-        Tensor::acos(self)
+        self.acos()
     }
 
     fn atan(&self) -> Self {
-        Tensor::atan(self)
+        self.atan()
     }
 
     fn sinh(&self) -> Self {
-        Tensor::sinh(self)
+        self.sinh()
     }
 
     fn cosh(&self) -> Self {
-        Tensor::cosh(self)
+        self.cosh()
     }
 
     fn tanh(&self) -> Self {
-        Tensor::tanh(self)
+        self.tanh()
     }
 
     fn asinh(&self) -> Self {
-        Tensor::asinh(self)
+        self.asinh()
     }
 
     fn acosh(&self) -> Self {
-        Tensor::acosh(self)
+        self.acosh()
     }
 
     fn atanh(&self) -> Self {
-        Tensor::atanh(self)
+        self.atanh()
     }
 
     fn lt<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::less_tensor(self, other.borrow())
+        self.lt_tensor(other.borrow())
     }
 
     fn lt_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::less(self, other)
+        self.lt(other)
     }
 
     fn gt<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::greater_tensor(self, other.borrow())
+        self.gt_tensor(other.borrow())
     }
 
     fn gt_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::greater(self, other)
+        self.gt(other)
     }
 
     fn le<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::le_tensor(self, other.borrow())
+        self.le_tensor(other.borrow())
     }
 
     fn le_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::le(self, other)
+        self.le(other)
     }
 
     fn ge<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::ge_tensor(self, other.borrow())
+        self.ge_tensor(other.borrow())
     }
 
     fn ge_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::ge(self, other)
+        self.ge(other)
     }
 
     fn eq<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::eq_tensor(self, other.borrow())
+        self.eq_tensor(other.borrow())
     }
 
     fn eq_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::eq(self, other)
+        self.eq(other)
     }
 
     fn ne<T: Borrow<Self>>(&self, other: T) -> Self {
-        Tensor::ne_tensor(self, other.borrow())
+        self.ne_tensor(other.borrow())
     }
 
     fn ne_scalar<S: Element>(&self, other: S) -> Self {
-        Tensor::ne(self, other)
+        self.ne(other)
+    }
+
+    fn r#where<T: Borrow<Self>, U: Borrow<Self>>(&self, condition: T, other: U) -> Self {
+        self.where_self(condition.borrow(), other.borrow())
+    }
+
+    fn gather<T: Borrow<Self>>(&self, dim: i64, indices: T) -> Self {
+        self.gather(dim, indices.borrow(), false)
+    }
+
+    fn squeeze(&self) -> Self {
+        self.squeeze()
+    }
+
+    fn squeeze_dim(&self, dim: i64) -> Self {
+        self.squeeze_dim(dim)
+    }
+
+    fn unsqueeze(&self, dim: i64) -> Self {
+        self.unsqueeze(dim)
     }
 }

--- a/src/core/tensor_like/tensor_ops.rs
+++ b/src/core/tensor_like/tensor_ops.rs
@@ -285,6 +285,9 @@ pub trait TensorOps:
     /// Gather slices from the tensor-like object along the given axis.
     fn gather<T: Borrow<Self>>(&self, dim: i64, indices: T) -> Self;
 
+    /// Scatter the tensor-like object along the given axis.
+    fn scatter<T: Borrow<Self>, U: Borrow<Self>>(&self, dim: i64, indices: T, src: U) -> Self;
+
     /// Returns a tensor-like object where all dimensions of size 1 are removed.
     fn squeeze(&self) -> Self;
 
@@ -295,6 +298,9 @@ pub trait TensorOps:
     ///
     /// The dimension index `axis` starts at zero; if you specify a negative number, it is counted backward from the end.
     fn unsqueeze(&self, dim: i64) -> Self;
+
+    /// Flatten the tensor-like object from `start_dim` to `end_dim` into a single dimension.
+    fn flatten(&self, start_dim: i64, end_dim: i64) -> Self;
 }
 
 impl TensorOps for Tensor {
@@ -485,6 +491,10 @@ impl TensorOps for Tensor {
     fn gather<T: Borrow<Self>>(&self, dim: i64, indices: T) -> Self {
         self.gather(dim, indices.borrow(), false)
     }
+    
+    fn scatter<T: Borrow<Self>, U: Borrow<Self>>(&self, dim: i64, indices: T, src: U) -> Self {
+        self.scatter(dim, indices.borrow(), src.borrow())
+    }
 
     fn squeeze(&self) -> Self {
         self.squeeze()
@@ -496,5 +506,9 @@ impl TensorOps for Tensor {
 
     fn unsqueeze(&self, dim: i64) -> Self {
         self.unsqueeze(dim)
+    }
+    
+    fn flatten(&self, start_dim: i64, end_dim: i64) -> Self {
+        self.flatten(start_dim, end_dim)
     }
 }

--- a/src/core/tensor_like/tensor_ops_ex.rs
+++ b/src/core/tensor_like/tensor_ops_ex.rs
@@ -1,0 +1,55 @@
+use tch::Tensor;
+
+use super::TensorOps;
+
+/// A trait for a tensor-like object that can perform advanced mathematical operations.
+///
+/// Advanced mathematical operations include:
+/// - Statistical operations
+/// - Advanced Linear Algebra operations
+/// - Other mathematical operations not included in [TensorOps]
+///
+/// Some of these operations may not strongly require extra low-level performance optimization (using gpu computing, cpu optimization or maybe just some parallel operations), so this trait gives a default implementation for them. But you can still override them if you want to.
+pub trait TensorOpsEx: TensorOps {
+    /// Draws binary random numbers (0 or 1) from a Bernoulli distribution.
+    ///
+    /// The input tensor should be a tensor of probabilities, and the output tensor will be a tensor of 0s and 1s.
+    fn bernoulli(&self) -> Self;
+
+    /// Computes the Cholesky decomposition of the symmetric positive-definite matrices.
+    ///
+    /// The input tensor should be a symmetric positive-definite matrix, or a batch of symmetric positive-definite matrices.
+    ///
+    /// The output tensor will be the lower triangular matrix of the Cholesky decomposition if `upper` is false, or the upper triangular matrix of the Cholesky decomposition if `upper` is true.
+    fn cholesky(&self, upper: bool) -> Self;
+
+    /// Computes the determinant of the square matrix or matrices.
+    /// 
+    /// The input tensor should be a square matrix, or a batch of square matrices.
+    fn det(&self) -> Self;
+
+    /// Computes the eigenvalues and eigenvectors of a square matrix or matrices.
+    /// 
+    /// The input tensor should be a square matrix, or a batch of square matrices.
+    /// 
+    /// The output tensor will be a tuple of two tensors. The first tensor will be the eigenvalues, and the second tensor will be the eigenvectors.
+    fn eig(&self) -> (Self, Self);
+}
+
+impl TensorOpsEx for Tensor {
+    fn bernoulli(&self) -> Self {
+        self.bernoulli()
+    }
+
+    fn cholesky(&self, upper: bool) -> Self {
+        self.cholesky(upper)
+    }
+
+    fn det(&self) -> Self {
+        self.det()
+    }
+
+    fn eig(&self) -> (Self, Self) {
+        self.eig(true)
+    }
+}

--- a/src/core/tensor_like/tensor_trans.rs
+++ b/src/core/tensor_like/tensor_trans.rs
@@ -1,0 +1,174 @@
+use tch::Tensor;
+
+use super::TensorOps;
+
+/// A trait for a tensor-like object that can perform basic algebraic operations on self.
+/// 
+/// These operations are largely similar to the operations in [TensorOps], but they are performed on self instead of another tensor, so they are more efficient and do not require to be put in a computational graph.
+/// 
+/// This trait will provide a default implementation for all the operations, but it's highly recommended to override them if you want to get better performance.
+pub trait TensorTrans: TensorOps {
+    /// In-place version of [TensorOps::transpose].
+    fn transpose_(&mut self, dim0: i64, dim1: i64) {
+        *self = self.transpose(dim0, dim1);
+    }
+
+    /// In-place version of [TensorOps::abs].
+    fn abs_(&mut self) {
+        *self = self.abs();
+    }
+
+    /// In-place version of [TensorOps::square].
+    fn square_(&mut self) {
+        *self = self.square();
+    }
+
+    /// In-place version of [TensorOps::sqrt].
+    fn sqrt_(&mut self) {
+        *self = self.sqrt();
+    }
+
+    /// In-place version of [TensorOps::exp].
+    fn exp_(&mut self) {
+        *self = self.exp();
+    }
+
+    /// In-place version of [TensorOps::log].
+    fn log_(&mut self) {
+        *self = self.log();
+    }
+
+    /// In-place version of [TensorOps::sin].
+    fn sin_(&mut self) {
+        *self = self.sin();
+    }
+
+    /// In-place version of [TensorOps::cos].
+    fn cos_(&mut self) {
+        *self = self.cos();
+    }
+
+    /// In-place version of [TensorOps::tan].
+    fn tan_(&mut self) {
+        *self = self.tan();
+    }
+
+    /// In-place version of [TensorOps::asin].
+    fn asin_(&mut self) {
+        *self = self.asin();
+    }
+
+    /// In-place version of [TensorOps::acos].
+    fn acos_(&mut self) {
+        *self = self.acos();
+    }
+
+    /// In-place version of [TensorOps::atan].
+    fn atan_(&mut self) {
+        *self = self.atan();
+    }
+
+    /// In-place version of [TensorOps::sinh].
+    fn sinh_(&mut self) {
+        *self = self.sinh();
+    }
+
+    /// In-place version of [TensorOps::cosh].
+    fn cosh_(&mut self) {
+        *self = self.cosh();
+    }
+
+    /// In-place version of [TensorOps::tanh].
+    fn tanh_(&mut self) {
+        *self = self.tanh();
+    }
+
+    /// In-place version of [TensorOps::asinh].
+    fn asinh_(&mut self) {
+        *self = self.asinh();
+    }
+
+    /// In-place version of [TensorOps::acosh].
+    fn acosh_(&mut self) {
+        *self = self.acosh();
+    }
+
+    /// In-place version of [TensorOps::atanh].
+    fn atanh_(&mut self) {
+        *self = self.atanh();
+    }
+}
+
+impl TensorTrans for Tensor {
+    fn transpose_(&mut self, dim0: i64, dim1: i64) {
+        let _ = self.transpose_(dim0, dim1);
+    }
+
+    fn abs_(&mut self) {
+        let _ = self.abs_();
+    }
+
+    fn square_(&mut self) {
+        let _ = self.square_();
+    }
+
+    fn sqrt_(&mut self) {
+        let _ = self.sqrt_();
+    }
+
+    fn exp_(&mut self) {
+        let _ = self.exp_();
+    }
+
+    fn log_(&mut self) {
+        let _ = self.log_();
+    }
+
+    fn sin_(&mut self) {
+        let _ = self.sin_();
+    }
+
+    fn cos_(&mut self) {
+        let _ = self.cos_();
+    }
+
+    fn tan_(&mut self) {
+        let _ = self.tan_();
+    }
+
+    fn asin_(&mut self) {
+        let _ = self.asin_();
+    }
+
+    fn acos_(&mut self) {
+        let _ = self.acos_();
+    }
+
+    fn atan_(&mut self) {
+        let _ = self.atan_();
+    }
+
+    fn sinh_(&mut self) {
+        let _ = self.sinh_();
+    }
+
+    fn cosh_(&mut self) {
+        let _ = self.cosh_();
+    }
+
+    fn tanh_(&mut self) {
+        let _ = self.tanh_();
+    }
+
+    fn asinh_(&mut self) {
+        let _ = self.asinh_();
+    }
+
+    fn acosh_(&mut self) {
+        let _ = self.acosh_();
+    }
+
+    fn atanh_(&mut self) {
+        let _ = self.atanh_();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(unsize)]
 #![feature(coerce_unsized)]
 #![feature(trait_upcasting)]
+#![feature(trait_alias)]
 
 extern crate self as raddar;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(coerce_unsized)]
 #![feature(trait_upcasting)]
 #![feature(trait_alias)]
+#![feature(associated_type_defaults)]
 
 extern crate self as raddar;
 

--- a/src/nn/act_funcs.rs
+++ b/src/nn/act_funcs.rs
@@ -1,21 +1,25 @@
-use raddar_derive::NonParameterModule;
+
+use raddar_derive::Module;
 
 use crate::{core::TensorNN, nn::Module};
 
 /// GeLU activation function.
 ///
 /// See [Gaussian Error Linear Units (GELUs)](https://arxiv.org/abs/1606.08415).
-#[derive(Debug, NonParameterModule)]
+#[derive(Debug, Module)]
+#[module(paramless)]
 pub struct GeLU;
 
 /// ReLU activation function.
 ///
 /// See [Rectified Linear Units Improve Restricted Boltzmann Machines](https://www.cs.toronto.edu/~fritz/absps/reluICML.pdf).
-#[derive(Debug, NonParameterModule)]
+#[derive(Debug, Module)]
+#[module(paramless)]
 pub struct ReLU;
 
 /// Leaky ReLU activation function.
-#[derive(Debug, NonParameterModule)]
+#[derive(Debug, Module)]
+#[module(paramless)]
 pub struct LeakyReLU {
     pub lambda: f64,
 }

--- a/src/nn/act_funcs.rs
+++ b/src/nn/act_funcs.rs
@@ -1,9 +1,6 @@
-use std::f64::consts::PI;
-
 use raddar_derive::NonParameterModule;
-use tch::Tensor;
 
-use crate::nn::Module;
+use crate::{core::TensorNN, nn::Module};
 
 /// GeLU activation function.
 ///
@@ -29,25 +26,20 @@ impl LeakyReLU {
     }
 }
 
-impl Module for GeLU {
-    fn forward(&self, input: &Tensor) -> Tensor {
-        let z = (input + &input.pow_tensor_scalar(3) * 0.044715) * (2.0f64 / PI).sqrt();
-        0.5 * input * (1 + z.tanh())
+impl<Ts: TensorNN> Module<Ts> for GeLU {
+    fn forward(&self, input: &Ts) -> Ts {
+        input.gelu()
     }
 }
-impl Module for ReLU {
-    fn forward(&self, input: &Tensor) -> Tensor {
-        let y = input.zeros_like();
-        let condition = input.ge(0);
-        input.where_self(&condition, &y)
+impl<Ts: TensorNN> Module<Ts> for ReLU {
+    fn forward(&self, input: &Ts) -> Ts {
+        input.relu()
     }
 }
 
-impl Module for LeakyReLU {
-    fn forward(&self, input: &Tensor) -> Tensor {
-        let y = -input * self.lambda;
-        let condition = input.ge(0);
-        input.where_self(&condition, &y)
+impl<Ts: TensorNN> Module<Ts> for LeakyReLU {
+    fn forward(&self, input: &Ts) -> Ts {
+        input.leaky_relu(self.lambda)
     }
 }
 

--- a/src/nn/alexnet.rs
+++ b/src/nn/alexnet.rs
@@ -1,4 +1,4 @@
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::{
     nn::{
@@ -13,8 +13,8 @@ use super::{Mod, TrainableDict};
 /// AlexNet architecture.
 ///
 /// See [ImageNet Classification with Deep Convolutional Neural Networks](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct AlexNet<Ts: TensorNN> {
     pub features: Mod<Sequential<Ts>, Ts>,
     pub avgpool: Mod<AdaptiveAveragePooling2D, Ts>,

--- a/src/nn/batchnorm.rs
+++ b/src/nn/batchnorm.rs
@@ -1,4 +1,4 @@
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use super::{module::Module, StateDict, Trainable};
 use crate::core::{Cellable, TensorCell, TensorNN};
@@ -6,8 +6,8 @@ use crate::core::{Cellable, TensorCell, TensorNN};
 /// A batch normalization layer in 1 dimension.
 ///
 /// See [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type = "Ts", builder)]
 pub struct BatchNorm1d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,
@@ -109,8 +109,8 @@ impl<Ts: TensorNN> BatchNorm1d<Ts> {
     }
 }
 
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type = "Ts", builder)]
 pub struct BatchNorm2d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,
@@ -212,8 +212,8 @@ impl<Ts: TensorNN> BatchNorm2d<Ts> {
 /// A batch normalization layer in 3 dimensions.
 ///
 /// See [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type = "Ts", builder)]
 pub struct BatchNorm3d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,

--- a/src/nn/batchnorm.rs
+++ b/src/nn/batchnorm.rs
@@ -1,14 +1,14 @@
 use raddar_derive::{ArchitectureBuilder, CallableModule};
-use tch::{Device, Kind, Tensor};
 
 use super::{module::Module, StateDict, Trainable};
-use crate::core::{Cellable, TensorCell};
+use crate::core::{Cellable, TensorCell, TensorNN};
 
 /// A batch normalization layer in 1 dimension.
 ///
 /// See [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct BatchNorm1d {
+#[module(tensor_type="Ts")]
+pub struct BatchNorm1d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,
     #[builder(default = "1e-5")]
@@ -21,14 +21,14 @@ pub struct BatchNorm1d {
     pub affine: bool,
     #[builder(default = "true")]
     pub training: bool,
-    pub bn_weight: Option<TensorCell>,
-    pub bn_bias: Option<TensorCell>,
-    pub running_mean: TensorCell,
-    pub running_var: TensorCell,
+    pub bn_weight: Option<TensorCell<Ts>>,
+    pub bn_bias: Option<TensorCell<Ts>>,
+    pub running_mean: TensorCell<Ts>,
+    pub running_var: TensorCell<Ts>,
 }
 
-impl Trainable for BatchNorm1d {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for BatchNorm1d<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         if self.affine {
             result.insert(
@@ -39,7 +39,7 @@ impl Trainable for BatchNorm1d {
         }
         result
     }
-    fn static_tensors(&self) -> StateDict {
+    fn static_tensors(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         result.insert("running_mean".to_owned(), self.running_mean.clone());
         result.insert("running_var".to_owned(), self.running_var.clone());
@@ -47,8 +47,8 @@ impl Trainable for BatchNorm1d {
     }
 }
 
-impl Module for BatchNorm1d {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for BatchNorm1d<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         assert!(input.dim() == 2 || input.dim() == 3);
         let running_mean = self.running_mean.lock();
         let running_var = self.running_var.lock();
@@ -59,8 +59,8 @@ impl Module for BatchNorm1d {
         input.batch_norm(
             bn_weight,
             bn_bias,
-            Some(&running_mean),
-            Some(&running_var),
+            Some(&*running_mean),
+            Some(&*running_var),
             self.training,
             self.momentum,
             self.eps,
@@ -72,11 +72,11 @@ impl Module for BatchNorm1d {
 /// A batch normalization layer in 2 dimensions.
 ///
 /// See [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).
-impl BatchNorm1d {
-    pub fn new(config: BatchNorm1dConfig) -> BatchNorm1d {
+impl<Ts: TensorNN> BatchNorm1d<Ts> {
+    pub fn new(config: BatchNorm1dConfig<Ts>) -> BatchNorm1d<Ts> {
         let bn_weight = if config.affine {
             Some(
-                Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::ones(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
@@ -85,15 +85,15 @@ impl BatchNorm1d {
         };
         let bn_bias = if config.affine {
             Some(
-                Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::zeros(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
         } else {
             None
         };
-        let running_mean = Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu));
-        let running_var = Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu));
+        let running_mean = Ts::zeros(&[config.num_features], Ts::Env::default());
+        let running_var = Ts::ones(&[config.num_features], Ts::Env::default());
         BatchNorm1d {
             num_features: config.num_features,
             eps: config.eps,
@@ -110,7 +110,8 @@ impl BatchNorm1d {
 }
 
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct BatchNorm2d {
+#[module(tensor_type="Ts")]
+pub struct BatchNorm2d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,
     #[builder(default = "1e-5")]
@@ -123,14 +124,14 @@ pub struct BatchNorm2d {
     pub affine: bool,
     #[builder(default = "true")]
     pub training: bool,
-    pub bn_weight: Option<TensorCell>,
-    pub bn_bias: Option<TensorCell>,
-    pub running_mean: TensorCell,
-    pub running_var: TensorCell,
+    pub bn_weight: Option<TensorCell<Ts>>,
+    pub bn_bias: Option<TensorCell<Ts>>,
+    pub running_mean: TensorCell<Ts>,
+    pub running_var: TensorCell<Ts>,
 }
 
-impl Trainable for BatchNorm2d {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for BatchNorm2d<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         if self.affine {
             result.insert(
@@ -141,7 +142,7 @@ impl Trainable for BatchNorm2d {
         }
         result
     }
-    fn static_tensors(&self) -> StateDict {
+    fn static_tensors(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         result.insert("running_mean".to_owned(), self.running_mean.clone());
         result.insert("running_var".to_owned(), self.running_var.clone());
@@ -149,8 +150,8 @@ impl Trainable for BatchNorm2d {
     }
 }
 
-impl Module for BatchNorm2d {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for BatchNorm2d<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         assert!(input.dim() == 4);
         let running_mean = self.running_mean.lock();
         let running_var = self.running_var.lock();
@@ -161,8 +162,8 @@ impl Module for BatchNorm2d {
         input.batch_norm(
             bn_weight,
             bn_bias,
-            Some(&running_mean),
-            Some(&running_var),
+            Some(&*running_mean),
+            Some(&*running_var),
             self.training,
             self.momentum,
             self.eps,
@@ -171,11 +172,11 @@ impl Module for BatchNorm2d {
     }
 }
 
-impl BatchNorm2d {
-    pub fn new(config: BatchNorm2dConfig) -> BatchNorm2d {
+impl<Ts: TensorNN> BatchNorm2d<Ts> {
+    pub fn new(config: BatchNorm2dConfig<Ts>) -> BatchNorm2d<Ts> {
         let bn_weight = if config.affine {
             Some(
-                Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::ones(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
@@ -184,15 +185,15 @@ impl BatchNorm2d {
         };
         let bn_bias = if config.affine {
             Some(
-                Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::zeros(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
         } else {
             None
         };
-        let running_mean = Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu));
-        let running_var = Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu));
+        let running_mean = Ts::zeros(&[config.num_features], Ts::Env::default());
+        let running_var = Ts::ones(&[config.num_features], Ts::Env::default());
         BatchNorm2d {
             num_features: config.num_features,
             eps: config.eps,
@@ -212,7 +213,8 @@ impl BatchNorm2d {
 ///
 /// See [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167).
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct BatchNorm3d {
+#[module(tensor_type="Ts")]
+pub struct BatchNorm3d<Ts: TensorNN> {
     #[builder]
     pub num_features: i64,
     #[builder(default = "1e-5")]
@@ -225,14 +227,14 @@ pub struct BatchNorm3d {
     pub affine: bool,
     #[builder(default = "true")]
     pub training: bool,
-    pub bn_weight: Option<TensorCell>,
-    pub bn_bias: Option<TensorCell>,
-    pub running_mean: TensorCell,
-    pub running_var: TensorCell,
+    pub bn_weight: Option<TensorCell<Ts>>,
+    pub bn_bias: Option<TensorCell<Ts>>,
+    pub running_mean: TensorCell<Ts>,
+    pub running_var: TensorCell<Ts>,
 }
 
-impl Trainable for BatchNorm3d {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for BatchNorm3d<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         if self.affine {
             result.insert(
@@ -243,7 +245,7 @@ impl Trainable for BatchNorm3d {
         }
         result
     }
-    fn static_tensors(&self) -> StateDict {
+    fn static_tensors(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         result.insert("running_mean".to_owned(), self.running_mean.clone());
         result.insert("running_var".to_owned(), self.running_var.clone());
@@ -251,8 +253,8 @@ impl Trainable for BatchNorm3d {
     }
 }
 
-impl Module for BatchNorm3d {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for BatchNorm3d<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         assert!(input.dim() == 5);
         let running_mean = self.running_mean.lock();
         let running_var = self.running_var.lock();
@@ -263,8 +265,8 @@ impl Module for BatchNorm3d {
         input.batch_norm(
             bn_weight,
             bn_bias,
-            Some(&running_mean),
-            Some(&running_var),
+            Some(&*running_mean),
+            Some(&*running_var),
             self.training,
             self.momentum,
             self.eps,
@@ -273,11 +275,11 @@ impl Module for BatchNorm3d {
     }
 }
 
-impl BatchNorm3d {
-    pub fn new(config: BatchNorm3dConfig) -> BatchNorm3d {
+impl<Ts: TensorNN> BatchNorm3d<Ts> {
+    pub fn new(config: BatchNorm3dConfig<Ts>) -> BatchNorm3d<Ts> {
         let bn_weight = if config.affine {
             Some(
-                Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::ones(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
@@ -286,15 +288,15 @@ impl BatchNorm3d {
         };
         let bn_bias = if config.affine {
             Some(
-                Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu))
+                Ts::zeros(&[config.num_features], Ts::Env::default())
                     .set_requires_grad(true)
                     .cell(),
             )
         } else {
             None
         };
-        let running_mean = Tensor::zeros(&[config.num_features], (Kind::Double, Device::Cpu));
-        let running_var = Tensor::ones(&[config.num_features], (Kind::Double, Device::Cpu));
+        let running_mean = Ts::zeros(&[config.num_features], Ts::Env::default());
+        let running_var = Ts::ones(&[config.num_features], Ts::Env::default());
         BatchNorm3d {
             num_features: config.num_features,
             eps: config.eps,

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,4 +1,4 @@
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::core::{Cellable, TensorCell, TensorNN};
 
@@ -7,8 +7,8 @@ use super::{Module, StateDict, Trainable};
 /// A Convolution layer in 1 dimension.
 ///
 /// See [Convolutional Neural Networks for Sentence Classification](https://arxiv.org/abs/1408.5882).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct Conv1d<Ts: TensorNN> {
     pub conv_weight: TensorCell<Ts>,
     pub conv_bias: Option<TensorCell<Ts>>,
@@ -94,8 +94,8 @@ impl<Ts: TensorNN> Conv1d<Ts> {
 }
 
 /// A Convolution layer in 2 dimensions.
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct Conv2d<Ts: TensorNN> {
     pub conv_weight: TensorCell<Ts>,
     pub conv_bias: Option<TensorCell<Ts>>,
@@ -184,8 +184,8 @@ impl<Ts: TensorNN> Conv2d<Ts> {
 }
 
 /// A convolution layer in 3 dimensions.
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct Conv3d<Ts: TensorNN> {
     pub conv_weight: TensorCell<Ts>,
     pub conv_bias: Option<TensorCell<Ts>>,

--- a/src/nn/densenet.rs
+++ b/src/nn/densenet.rs
@@ -1,4 +1,4 @@
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::{seq, core::TensorNN};
 
@@ -37,7 +37,7 @@ pub fn transition<Ts: TensorNN>(num_input_features: i64, num_output_features: i6
     Mod::new(res)
 }
 
-#[derive(Debug, CallableModule)]
+#[derive(Debug, Module)]
 #[module(tensor_type = "Ts")]
 pub struct DenseLayer<Ts: TensorNN> {
     modules: ModuleDict<Ts>,
@@ -131,8 +131,8 @@ pub fn denselayer<Ts: TensorNN>(
         drop_rate,
     ))
 }
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct DenseBlock<Ts: TensorNN> {
     #[builder]
     pub num_layers: i64,
@@ -188,8 +188,8 @@ impl<Ts: TensorNN> DenseBlock<Ts> {
         }
     }
 }
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct DenseNet<Ts: TensorNN> {
     pub features: NamedSequential<Ts>,
     pub classifier: Mod<Linear<Ts>, Ts>,

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,6 +1,7 @@
+use crate::core::TensorNN;
+
 use super::Module;
 use raddar_derive::{ArchitectureBuilder, CallableModule, NonParameterModule};
-use tch::Tensor;
 
 /// A dropout layer.
 #[derive(ArchitectureBuilder, Debug, CallableModule, NonParameterModule)]
@@ -11,8 +12,8 @@ pub struct Dropout {
     train: bool,
 }
 
-impl Module for Dropout {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for Dropout {
+    fn forward(&self, input: &Ts) -> Ts {
         input.dropout(self.p, self.train)
     }
 }

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,10 +1,12 @@
+use raddar_derive::Module;
+
 use crate::core::TensorNN;
 
 use super::Module;
-use raddar_derive::{ArchitectureBuilder, CallableModule, NonParameterModule};
 
 /// A dropout layer.
-#[derive(ArchitectureBuilder, Debug, CallableModule, NonParameterModule)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct Dropout {
     #[builder(default = "0.5")]
     p: f64,

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -1,7 +1,6 @@
 use raddar_derive::{CallableModule, NonParameterModule};
-use tch::{no_grad, Device, Kind, Tensor};
 
-use crate::core::{Cellable, TensorCell};
+use crate::core::{Cellable, TensorCell, TensorNN};
 
 use super::{Module, StateDict, Trainable};
 
@@ -13,11 +12,11 @@ pub struct OneHot {
     pub num_classes: i64,
 }
 
-impl Module for OneHot {
-    fn forward(&self, input: &tch::Tensor) -> tch::Tensor {
-        let mut original_size = input.size(); //(32,1)
+impl<Ts: TensorNN> Module<Ts> for OneHot {
+    fn forward(&self, input: &Ts) -> Ts {
+        let mut original_size = input.shape(); //(32,1)
         original_size.push(self.num_classes); //(32,1,10)
-        let one_hot = Tensor::zeros(&original_size, (input.kind(), input.device()));
+        let one_hot = Ts::zeros(&original_size, input.env());
         let input = input.unsqueeze(-1); //(32,1,1)
         let one_hot = one_hot.scatter(-1, &input, &input.ones_like());
         // one_hot.squeeze_dim(-2)
@@ -35,24 +34,23 @@ impl OneHot {
 ///
 /// See [Distributed Representations of Words and Phrases and their Compositionality](https://arxiv.org/abs/1310.4546).
 #[derive(Debug, CallableModule)]
-pub struct Embedding {
+#[module(tensor_type="Ts")]
+pub struct Embedding<Ts: TensorNN> {
     pub num_embeddings: i64,
     pub embedding_dim: i64,
-    pub weight: TensorCell,
+    pub weight: TensorCell<Ts>,
     one_hot: OneHot,
 }
 
-impl Embedding {
+impl<Ts: TensorNN> Embedding<Ts> {
     pub fn new(num_embeddings: i64, embedding_dim: i64) -> Self {
-        let mut weight = Tensor::empty(
+        let mut weight = Ts::empty(
             &[num_embeddings, embedding_dim],
-            (Kind::Double, Device::Cpu),
+            Ts::Env::default(),
         )
         .set_requires_grad(true);
 
-        no_grad(|| {
-            weight.init(tch::nn::Init::Uniform { lo: 0., up: 1. });
-        });
+        weight.no_grad_mut().uniform_(0., 1.);
 
         Self {
             num_embeddings,
@@ -63,18 +61,18 @@ impl Embedding {
     }
 }
 
-impl Trainable for Embedding {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for Embedding<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         result.insert("weight".to_owned(), self.weight.clone());
         result
     }
 }
 
-impl Module for Embedding {
-    fn forward(&self, input: &tch::Tensor) -> tch::Tensor {
+impl<Ts: TensorNN> Module<Ts> for Embedding<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let one_hotted = (self.one_hot)(input);
         let weight = self.weight.lock();
-        one_hotted.type_as(&weight).matmul(&weight)
+        one_hotted.type_as(&*weight).matmul(&*weight)
     }
 }

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -1,4 +1,4 @@
-use raddar_derive::{CallableModule, NonParameterModule};
+use raddar_derive::Module;
 
 use crate::core::{Cellable, TensorCell, TensorNN};
 
@@ -7,7 +7,8 @@ use super::{Module, StateDict, Trainable};
 /// A one-hot embedding layer.
 ///
 /// This layer is used to convert a sequence of integers into a sequence of one-hot vectors.
-#[derive(Debug, CallableModule, NonParameterModule)]
+#[derive(Debug, Module)]
+#[module(paramless)]
 pub struct OneHot {
     pub num_classes: i64,
 }
@@ -33,7 +34,7 @@ impl OneHot {
 /// An embedding layer.
 ///
 /// See [Distributed Representations of Words and Phrases and their Compositionality](https://arxiv.org/abs/1310.4546).
-#[derive(Debug, CallableModule)]
+#[derive(Debug, Module)]
 #[module(tensor_type="Ts")]
 pub struct Embedding<Ts: TensorNN> {
     pub num_embeddings: i64,

--- a/src/nn/layernorm.rs
+++ b/src/nn/layernorm.rs
@@ -1,12 +1,13 @@
+use raddar_derive::Module;
+
 use super::{module::Module, StateDict, Trainable};
 use crate::core::{Cellable, TensorCell, TensorNN};
-use raddar_derive::{ArchitectureBuilder, CallableModule};
 
 /// A layer normalization layer.
 ///
 /// See [Layer Normalization](https://arxiv.org/abs/1607.06450).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct LayerNorm<Ts: TensorNN> {
     pub ln_weight: Option<TensorCell<Ts>>,
     pub ln_bias: Option<TensorCell<Ts>>,

--- a/src/nn/layernorm.rs
+++ b/src/nn/layernorm.rs
@@ -1,15 +1,15 @@
 use super::{module::Module, StateDict, Trainable};
-use crate::core::{Cellable, TensorCell};
+use crate::core::{Cellable, TensorCell, TensorNN};
 use raddar_derive::{ArchitectureBuilder, CallableModule};
-use tch::{Device, Kind, Tensor};
 
 /// A layer normalization layer.
 ///
 /// See [Layer Normalization](https://arxiv.org/abs/1607.06450).
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct LayerNorm {
-    pub ln_weight: Option<TensorCell>,
-    pub ln_bias: Option<TensorCell>,
+#[module(tensor_type="Ts")]
+pub struct LayerNorm<Ts: TensorNN> {
+    pub ln_weight: Option<TensorCell<Ts>>,
+    pub ln_bias: Option<TensorCell<Ts>>,
     #[builder]
     pub shape: Vec<i64>,
     #[builder(default = "1e-5")]
@@ -20,8 +20,8 @@ pub struct LayerNorm {
     pub elementwise_affine: bool,
 }
 
-impl Trainable for LayerNorm {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for LayerNorm<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         if self.elementwise_affine {
             result.insert(
@@ -34,8 +34,8 @@ impl Trainable for LayerNorm {
     }
 }
 
-impl Module for LayerNorm {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for LayerNorm<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let ln_weight = self.ln_weight.as_ref().map(|weight| weight.lock());
         let ln_weight = ln_weight.as_deref();
         let ln_bias = self.ln_bias.as_ref().map(|bias| bias.lock());
@@ -50,16 +50,16 @@ impl Module for LayerNorm {
     }
 }
 
-impl LayerNorm {
-    pub fn new(config: LayerNormConfig) -> LayerNorm {
+impl<Ts: TensorNN> LayerNorm<Ts> {
+    pub fn new(config: LayerNormConfig<Ts>) -> LayerNorm<Ts> {
         let size = &*config.shape;
         let ln_weight = if config.elementwise_affine {
-            Some(Tensor::ones(size, (Kind::Double, Device::Cpu)).cell())
+            Some(Ts::ones(size, Ts::Env::default()).cell())
         } else {
             None
         };
         let ln_bias = if config.elementwise_affine {
-            Some(Tensor::zeros(size, (Kind::Double, Device::Cpu)).cell())
+            Some(Ts::zeros(size, Ts::Env::default()).cell())
         } else {
             None
         };

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,15 +1,15 @@
 use raddar_derive::{ArchitectureBuilder, CallableModule};
-use tch::{no_grad, Device, Kind, Tensor};
 
-use crate::core::{Cellable, TensorCell};
+use crate::core::{Cellable, TensorCell, TensorNN};
 
-use super::{module::Module, Trainable, StateDict};
+use super::{module::Module, StateDict, Trainable};
 
 // A simple fully-connected layer.
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct Linear {
-    pub linear_weight: TensorCell,
-    pub linear_bias: Option<TensorCell>,
+#[module(tensor_type="Ts")]
+pub struct Linear<Ts: TensorNN> {
+    pub linear_weight: TensorCell<Ts>,
+    pub linear_bias: Option<TensorCell<Ts>>,
     #[builder]
     pub input_dim: i64,
     #[builder]
@@ -18,8 +18,8 @@ pub struct Linear {
     pub bias: bool,
 }
 
-impl Trainable for Linear {
-    fn parameters(&self) -> StateDict {
+impl<Ts: TensorNN> Trainable<Ts> for Linear<Ts> {
+    fn parameters(&self) -> StateDict<Ts> {
         let mut result = StateDict::new();
         result.insert("weight".to_owned(), self.linear_weight.clone());
         if let Some(bias) = &self.linear_bias {
@@ -29,33 +29,30 @@ impl Trainable for Linear {
     }
 }
 
-impl Module for Linear {
-    fn forward(&self, input: &Tensor) -> Tensor {
-        let weight = &self.linear_weight.lock();
+impl<Ts: TensorNN> Module<Ts> for Linear<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
+        let weight = self.linear_weight.lock();
         if let Some(bias) = &self.linear_bias {
             let bias = bias.lock();
-            input.matmul(&weight) + &*bias
+            input.matmul(&*weight) + &*bias
         } else {
-            input.matmul(&weight)
+            input.matmul(&*weight)
         }
     }
 }
 
-impl Linear {
-    pub fn new(config: LinearConfig) -> Linear {
+impl<Ts: TensorNN> Linear<Ts> {
+    pub fn new(config: LinearConfig<Ts>) -> Linear<Ts> {
         let input_dim = config.input_dim;
         let output_dim = config.output_dim;
         let bias = config.bias;
-        let mut weight = Tensor::empty(&[input_dim, output_dim], (Kind::Double, Device::Cpu))
+        let mut weight = Ts::empty(&[input_dim, output_dim], Ts::Env::default())
             .set_requires_grad(true);
 
-        let mut linear_bias =
-            Tensor::empty(&[output_dim], (Kind::Double, Device::Cpu)).set_requires_grad(true);
+        let mut linear_bias = Ts::empty(&[output_dim], Ts::Env::default()).set_requires_grad(true);
 
-        no_grad(|| {
-            weight.init(tch::nn::Init::KaimingUniform);
-            linear_bias.init(tch::nn::Init::KaimingUniform);
-        });
+        weight.no_grad_mut().kaiming_uniform_();
+        linear_bias.no_grad_mut().kaiming_uniform_();
         Linear {
             linear_weight: weight.cell(),
             linear_bias: if bias { Some(linear_bias.cell()) } else { None },

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,12 +1,12 @@
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::core::{Cellable, TensorCell, TensorNN};
 
 use super::{module::Module, StateDict, Trainable};
 
 // A simple fully-connected layer.
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct Linear<Ts: TensorNN> {
     pub linear_weight: TensorCell<Ts>,
     pub linear_bias: Option<TensorCell<Ts>>,

--- a/src/nn/pooling.rs
+++ b/src/nn/pooling.rs
@@ -1,11 +1,12 @@
-use raddar_derive::{NonParameterModule, CallableModule, ArchitectureBuilder};
+use raddar_derive::Module;
 
 use crate::core::TensorNN;
 
 use super::Module;
 
 /// A max pooling layer in 1 dimension.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct MaxPooling1D {
     #[builder]
     pub kernel_size: [i64; 1],
@@ -48,7 +49,8 @@ impl<Ts: TensorNN> Module<Ts> for MaxPooling1D {
 }
 
 /// A max pooling layer in 2 dimensions.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct MaxPooling2D {
     #[builder]
     pub kernel_size: [i64; 2],
@@ -91,7 +93,8 @@ impl<Ts: TensorNN> Module<Ts> for MaxPooling2D {
 }
 
 /// A max pooling layer in 3 dimensions.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct MaxPooling3D {
     #[builder]
     pub kernel_size: [i64; 3],
@@ -134,7 +137,8 @@ impl<Ts: TensorNN> Module<Ts> for MaxPooling3D {
 }
 
 /// An average pooling layer in 1 dimension.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AveragePooling1D {
     #[builder(default = "[3]")]
     pub kernel_size: [i64; 1],
@@ -177,7 +181,8 @@ impl<Ts: TensorNN> Module<Ts> for AveragePooling1D {
 }
 
 /// An average pooling layer in 2 dimensions.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 
 pub struct AveragePooling2D {
     #[builder(default = "[3, 3]")]
@@ -226,7 +231,8 @@ impl<Ts: TensorNN> Module<Ts> for AveragePooling2D {
 }
 
 /// An average pooling layer in 3 dimensions.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AveragePooling3D {
     #[builder(default = "[3, 3, 3]")]
     pub kernel_size: [i64; 3],
@@ -274,7 +280,8 @@ impl<Ts: TensorNN> Module<Ts> for AveragePooling3D {
 }
 
 /// An adaptive max pooling layer in 1 dimension, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveMaxPooling1D {
     #[builder(default = "[1]")]
     pub output_size: [i64; 1],
@@ -295,7 +302,8 @@ impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling1D {
 }
 
 /// An adaptive max pooling layer in 2 dimensions, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveMaxPooling2D {
     #[builder(default = "[1, 1]")]
     pub output_size: [i64; 2],
@@ -316,7 +324,8 @@ impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling2D {
 }
 
 /// An adaptive max pooling layer in 3 dimensions, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveMaxPooling3D {
     #[builder(default = "[1, 1, 1]")]
     pub output_size: [i64; 3],
@@ -337,7 +346,8 @@ impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling3D {
 }
 
 /// An adaptive average pooling layer in 1 dimension, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveAveragePooling1D {
     #[builder(default = "[1]")]
     pub output_size: [i64; 1],
@@ -358,7 +368,8 @@ impl<Ts: TensorNN> Module<Ts> for AdaptiveAveragePooling1D {
 }
 
 /// An adaptive average pooling layer in 2 dimensions, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveAveragePooling2D {
     #[builder(default = "[1, 1]")]
     pub output_size: [i64; 2],
@@ -379,7 +390,8 @@ impl<Ts: TensorNN> Module<Ts> for AdaptiveAveragePooling2D {
 }
 
 /// An adaptive average pooling layer in 3 dimensions, which outputs a fixed size vector.
-#[derive(Debug, CallableModule, NonParameterModule, ArchitectureBuilder)]
+#[derive(Debug, Module)]
+#[module(paramless, builder)]
 pub struct AdaptiveAveragePooling3D {
     #[builder(default = "[1, 1, 1]")]
     pub output_size: [i64; 3],

--- a/src/nn/pooling.rs
+++ b/src/nn/pooling.rs
@@ -1,5 +1,6 @@
-use raddar_derive::{CallableModule, NonParameterModule, ArchitectureBuilder};
-use tch::Tensor;
+use raddar_derive::{NonParameterModule, CallableModule, ArchitectureBuilder};
+
+use crate::core::TensorNN;
 
 use super::Module;
 
@@ -34,8 +35,8 @@ impl MaxPooling1D {
     }
 }
 
-impl Module for MaxPooling1D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for MaxPooling1D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.max_pool1d(
             &self.kernel_size,
             &self.stride,
@@ -77,8 +78,8 @@ impl MaxPooling2D {
     }
 }
 
-impl Module for MaxPooling2D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for MaxPooling2D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.max_pool2d(
             &self.kernel_size,
             &self.stride,
@@ -120,8 +121,8 @@ impl MaxPooling3D {
     }
 }
 
-impl Module for MaxPooling3D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for MaxPooling3D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.max_pool3d(
             &self.kernel_size,
             &self.stride,
@@ -163,8 +164,8 @@ impl AveragePooling1D {
     }
 }
 
-impl Module for AveragePooling1D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AveragePooling1D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.avg_pool1d(
             &self.kernel_size,
             &self.stride,
@@ -211,8 +212,8 @@ impl AveragePooling2D {
     }
 }
 
-impl Module for AveragePooling2D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AveragePooling2D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.avg_pool2d(
             &self.kernel_size,
             &self.stride,
@@ -259,8 +260,8 @@ impl AveragePooling3D {
     }
 }
 
-impl Module for AveragePooling3D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AveragePooling3D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.avg_pool3d(
             &self.kernel_size,
             &self.stride,
@@ -287,8 +288,8 @@ impl AdaptiveMaxPooling1D {
     }
 }
 
-impl Module for AdaptiveMaxPooling1D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling1D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_max_pool1d(&self.output_size).0
     }
 }
@@ -308,8 +309,8 @@ impl AdaptiveMaxPooling2D {
     }
 }
 
-impl Module for AdaptiveMaxPooling2D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling2D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_max_pool2d(&self.output_size).0
     }
 }
@@ -329,8 +330,8 @@ impl AdaptiveMaxPooling3D {
     }
 }
 
-impl Module for AdaptiveMaxPooling3D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveMaxPooling3D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_max_pool3d(&self.output_size).0
     }
 }
@@ -350,8 +351,8 @@ impl AdaptiveAveragePooling1D {
     }
 }
 
-impl Module for AdaptiveAveragePooling1D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveAveragePooling1D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_avg_pool1d(&self.output_size)
     }
 }
@@ -371,8 +372,8 @@ impl AdaptiveAveragePooling2D {
     }
 }
 
-impl Module for AdaptiveAveragePooling2D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveAveragePooling2D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_avg_pool2d(&self.output_size)
     }
 }
@@ -392,8 +393,8 @@ impl AdaptiveAveragePooling3D {
     }
 }
 
-impl Module for AdaptiveAveragePooling3D {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for AdaptiveAveragePooling3D {
+    fn forward(&self, input: &Ts) -> Ts {
         input.adaptive_avg_pool3d(&self.output_size)
     }
 }

--- a/src/nn/resnet.rs
+++ b/src/nn/resnet.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::{nn::ReLU, seq, core::TensorNN};
 
@@ -58,7 +58,7 @@ pub fn batchnorm2d<Ts: TensorNN>(num_features: i64) -> Mod<Sequential<Ts>, Ts> {
         .build())
 }
 
-#[derive(Debug, CallableModule)]
+#[derive(Debug, Module)]
 #[module(tensor_type="Ts")]
 pub struct BasicBlock<Ts: TensorNN> {
     pub block: Mod<Sequential<Ts>, Ts>,
@@ -119,7 +119,7 @@ impl<U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> 
     }
 }
 
-#[derive(Debug, CallableModule)]
+#[derive(Debug, Module)]
 #[module(tensor_type="Ts")]
 pub struct BottleNeck<Ts: TensorNN> {
     pub block: Mod<Sequential<Ts>, Ts>,
@@ -188,8 +188,8 @@ impl<U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> 
 /// A ResNet model
 ///
 /// See [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct ResNet<
     T: Block<U, Ts> + 'static,
     U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy + 'static,

--- a/src/nn/resnet.rs
+++ b/src/nn/resnet.rs
@@ -1,16 +1,15 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use raddar_derive::{ArchitectureBuilder, CallableModule};
-use tch::Tensor;
 
-use crate::{nn::ReLU, seq};
+use crate::{nn::ReLU, seq, core::TensorNN};
 
 use super::{
     AdaptiveAveragePooling2DBuilder, BatchNorm2dBuilder, Conv2d, Conv2dBuilder, LinearBuilder,
     MaxPooling2DBuilder, Mod, Module, Sequential, Trainable, TrainableDict,
 };
 
-pub trait Block<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy>: Module {
+pub trait Block<U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN>: Module<Ts> {
     fn expansion() -> i64;
     fn new_block(
         inplanes: i64,
@@ -19,18 +18,18 @@ pub trait Block<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy>: Module {
         groups: i64,
         base_width: i64,
         dilation: [i64; 2],
-        downsample: Option<Mod<Sequential>>,
+        downsample: Option<Mod<Sequential<Ts>, Ts>>,
         norm_layer: U,
-    ) -> Mod<Self>;
+    ) -> Mod<Self, Ts>;
 }
 
-pub fn conv3x3(
+pub fn conv3x3<Ts: TensorNN>(
     in_planes: i64,
     out_planes: i64,
     stride: [i64; 2],
     groups: i64,
     dilation: [i64; 2],
-) -> Mod<Conv2d> {
+) -> Mod<Conv2d<Ts>, Ts> {
     Conv2dBuilder::default()
         .kernel_size([3, 3])
         .in_channel(in_planes)
@@ -43,7 +42,7 @@ pub fn conv3x3(
         .build()
 }
 
-pub fn conv1x1(in_planes: i64, out_planes: i64, stride: [i64; 2]) -> Mod<Conv2d> {
+pub fn conv1x1<Ts: TensorNN>(in_planes: i64, out_planes: i64, stride: [i64; 2]) -> Mod<Conv2d<Ts>, Ts> {
     Conv2dBuilder::default()
         .kernel_size([1, 1])
         .in_channel(in_planes)
@@ -53,20 +52,21 @@ pub fn conv1x1(in_planes: i64, out_planes: i64, stride: [i64; 2]) -> Mod<Conv2d>
         .build()
 }
 
-pub fn batchnorm2d(num_features: i64) -> Mod<Sequential> {
+pub fn batchnorm2d<Ts: TensorNN>(num_features: i64) -> Mod<Sequential<Ts>, Ts> {
     seq!(BatchNorm2dBuilder::default()
         .num_features(num_features)
         .build())
 }
 
 #[derive(Debug, CallableModule)]
-pub struct BasicBlock {
-    pub block: Mod<Sequential>,
-    pub downsample: Option<Mod<Sequential>>,
+#[module(tensor_type="Ts")]
+pub struct BasicBlock<Ts: TensorNN> {
+    pub block: Mod<Sequential<Ts>, Ts>,
+    pub downsample: Option<Mod<Sequential<Ts>, Ts>>,
 }
 
-impl Trainable for BasicBlock {
-    fn child_modules(&self) -> TrainableDict {
+impl<Ts: TensorNN> Trainable<Ts> for BasicBlock<Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut result = TrainableDict::new();
         result.insert("block".to_owned(), self.block.clone());
         if let Some(ref downsample) = self.downsample {
@@ -76,8 +76,8 @@ impl Trainable for BasicBlock {
     }
 }
 
-impl Module for BasicBlock {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for BasicBlock<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut identity = input.copy();
         let mut output = (self.block)(input);
         if let Some(downsample) = &self.downsample {
@@ -89,7 +89,7 @@ impl Module for BasicBlock {
     }
 }
 
-impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BasicBlock {
+impl<U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> Block<U, Ts> for BasicBlock<Ts> {
     fn expansion() -> i64 {
         1
     }
@@ -101,11 +101,11 @@ impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BasicBloc
         groups: i64,
         base_width: i64,
         dilation: [i64; 2],
-        downsample: Option<Mod<Sequential>>,
+        downsample: Option<Mod<Sequential<Ts>, Ts>>,
         norm_layer: U,
-    ) -> Mod<Self> {
+    ) -> Mod<Self, Ts> {
         assert!(groups == 1 && base_width == 64 && dilation == [1, 1]);
-        let mut block: Sequential = Sequential::default();
+        let mut block = Sequential::default();
         block.push(conv3x3(in_planes, planes, stride, groups, dilation));
         block.push(norm_layer(planes));
         block.push(Mod::new(ReLU));
@@ -120,13 +120,14 @@ impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BasicBloc
 }
 
 #[derive(Debug, CallableModule)]
-pub struct BottleNeck {
-    pub block: Mod<Sequential>,
-    pub downsample: Option<Mod<Sequential>>,
+#[module(tensor_type="Ts")]
+pub struct BottleNeck<Ts: TensorNN> {
+    pub block: Mod<Sequential<Ts>, Ts>,
+    pub downsample: Option<Mod<Sequential<Ts>, Ts>>,
 }
 
-impl Trainable for BottleNeck {
-    fn child_modules(&self) -> TrainableDict {
+impl<Ts: TensorNN> Trainable<Ts> for BottleNeck<Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut result = TrainableDict::new();
         result.insert("block".to_owned(), self.block.clone());
         if let Some(downsample) = &self.downsample {
@@ -136,8 +137,8 @@ impl Trainable for BottleNeck {
     }
 }
 
-impl Module for BottleNeck {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for BottleNeck<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut identity = input.copy();
         let mut output = (self.block)(input);
         if let Some(downsample) = &self.downsample {
@@ -149,7 +150,7 @@ impl Module for BottleNeck {
     }
 }
 
-impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BottleNeck {
+impl<U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> Block<U, Ts> for BottleNeck<Ts> {
     fn expansion() -> i64 {
         4
     }
@@ -160,9 +161,9 @@ impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BottleNec
         groups: i64,
         base_width: i64,
         dilation: [i64; 2],
-        downsample: Option<Mod<Sequential>>,
+        downsample: Option<Mod<Sequential<Ts>, Ts>>,
         norm_layer: U,
-    ) -> Mod<Self> {
+    ) -> Mod<Self, Ts> {
         let width = (((planes as f64) * (base_width as f64) / 64.0) as i64) * groups;
         let mut block = Sequential::default();
         block.push(conv1x1(inplanes, width, [1, 1]));
@@ -173,10 +174,10 @@ impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BottleNec
         block.push(Mod::new(ReLU));
         block.push(conv1x1(
             width,
-            planes * <BottleNeck as Block<U>>::expansion(),
+            planes * <BottleNeck<Ts> as Block<U, Ts>>::expansion(),
             [1, 1],
         ));
-        block.push(norm_layer(planes * <BottleNeck as Block<U>>::expansion()));
+        block.push(norm_layer(planes * <BottleNeck<Ts> as Block<U, Ts>>::expansion()));
         Mod::new(Self {
             block: Mod::new(block),
             downsample,
@@ -188,9 +189,11 @@ impl<U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Block<U> for BottleNec
 ///
 /// See [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
+#[module(tensor_type="Ts")]
 pub struct ResNet<
-    T: Block<U> + 'static,
-    U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy + 'static,
+    T: Block<U, Ts> + 'static,
+    U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy + 'static,
+    Ts: TensorNN
 > {
     #[builder(default = "64")]
     pub base_width: i64,
@@ -198,8 +201,8 @@ pub struct ResNet<
     pub num_classes: i64,
     #[builder]
     pub layers: [i64; 4],
-    pub net: Mod<Sequential>,
-    pub fc: Mod<Sequential>,
+    pub net: Mod<Sequential<Ts>, Ts>,
+    pub fc: Mod<Sequential<Ts>, Ts>,
     #[builder(default = "[false, false, false]")]
     pub replace_stride_with_dilation: [bool; 3],
     #[builder(default = "1")]
@@ -214,28 +217,28 @@ pub struct ResNet<
     _phantom: PhantomData<T>,
 }
 
-trait DefaultNormLayer<U: Fn(i64) -> Mod<Sequential>> {
+trait DefaultNormLayer<U: Fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts: TensorNN> {
     fn default_norm_layer() -> U;
 }
 
-impl<T: Block<U>, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> DefaultNormLayer<U>
-    for ResNetBuilder<T, U>
+impl<T: Block<U, Ts>, U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> DefaultNormLayer<U, Ts>
+    for ResNetBuilder<T, U, Ts>
 {
     default fn default_norm_layer() -> U {
         panic!("Norm layer should be set!")
     }
 }
 
-impl<T: Block<fn(i64) -> Mod<Sequential>>> DefaultNormLayer<fn(i64) -> Mod<Sequential>>
-    for ResNetBuilder<T, fn(i64) -> Mod<Sequential>>
+impl<T: Block<fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts: TensorNN> DefaultNormLayer<fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>
+    for ResNetBuilder<T, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>
 {
-    fn default_norm_layer() -> fn(i64) -> Mod<Sequential> {
+    fn default_norm_layer() -> fn(i64) -> Mod<Sequential<Ts>, Ts> {
         return batchnorm2d;
     }
 }
 
-impl<T: Block<U>, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Trainable for ResNet<T, U> {
-    fn child_modules(&self) -> TrainableDict {
+impl<T: Block<U, Ts>, U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> Trainable<Ts> for ResNet<T, U, Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut result = TrainableDict::new();
         result.insert("net".to_owned(), self.net.clone());
         result.insert("fc".to_owned(), self.fc.clone());
@@ -243,8 +246,8 @@ impl<T: Block<U>, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Trainable
     }
 }
 
-impl<T: Block<U>, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Module for ResNet<T, U> {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<T: Block<U, Ts>, U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> Module<Ts> for ResNet<T, U, Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut output = (self.net)(input);
         output = output.flatten(1, 3);
         output = (self.fc)(&output);
@@ -252,8 +255,8 @@ impl<T: Block<U>, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> Module fo
     }
 }
 
-impl<T: Block<U> + 'static, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy> ResNet<T, U> {
-    fn new(config: ResNetConfig<T, U>) -> ResNet<T, U> {
+impl<T: Block<U, Ts> + 'static, U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN> ResNet<T, U, Ts> {
+    fn new(config: ResNetConfig<T, U, Ts>) -> ResNet<T, U, Ts> {
         let mut config = config;
         let mut net = Sequential::default();
         net.push(
@@ -304,13 +307,13 @@ impl<T: Block<U> + 'static, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy>
     }
 }
 
-fn make_layer<T: Block<U> + 'static, U: Fn(i64) -> Mod<Sequential> + Send + Debug + Copy>(
+fn make_layer<T: Block<U, Ts> + 'static, U: Fn(i64) -> Mod<Sequential<Ts>, Ts> + Send + Debug + Copy, Ts: TensorNN>(
     normlayer: U,
-    config: &mut ResNetConfig<T, U>,
+    config: &mut ResNetConfig<T, U, Ts>,
     planes: i64,
     mut stride: [i64; 2],
     id: i64,
-) -> Mod<Sequential> {
+) -> Mod<Sequential<Ts>, Ts> {
     let mut dilate = false;
     if id > 0 {
         dilate = config.replace_stride_with_dilation[(id - 1) as usize];
@@ -362,40 +365,40 @@ fn make_layer<T: Block<U> + 'static, U: Fn(i64) -> Mod<Sequential> + Send + Debu
 }
 
 /// ResNet18 model from "Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>
-pub fn resnet18(num_classes: i64) -> Mod<ResNet<BasicBlock, fn(i64) -> Mod<Sequential>>> {
-    ResNetBuilder::<BasicBlock, fn(i64) -> Mod<Sequential>>::default()
+pub fn resnet18<Ts: TensorNN>(num_classes: i64) -> Mod<ResNet<BottleNeck<Ts>, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts> {
+    ResNetBuilder::default()
         .layers([2, 2, 2, 2])
         .num_classes(num_classes)
         .build()
 }
 
 /// ResNet34 model from "Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>
-pub fn resnet34(num_classes: i64) -> Mod<ResNet<BasicBlock, fn(i64) -> Mod<Sequential>>> {
-    ResNetBuilder::<BasicBlock, fn(i64) -> Mod<Sequential>>::default()
+pub fn resnet34<Ts: TensorNN>(num_classes: i64) -> Mod<ResNet<BottleNeck<Ts>, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts> {
+    ResNetBuilder::default()
         .layers([3, 4, 6, 3])
         .num_classes(num_classes)
         .build()
 }
 
 /// ResNet50 model from "Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>
-pub fn resnet50(num_classes: i64) -> Mod<ResNet<BottleNeck, fn(i64) -> Mod<Sequential>>> {
-    ResNetBuilder::<BottleNeck, fn(i64) -> Mod<Sequential>>::default()
+pub fn resnet50<Ts: TensorNN>(num_classes: i64) -> Mod<ResNet<BottleNeck<Ts>, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts> {
+    ResNetBuilder::default()
         .layers([3, 4, 6, 3])
         .num_classes(num_classes)
         .build()
 }
 
 /// ResNet101 model from "Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>
-pub fn resnet101(num_classes: i64) -> Mod<ResNet<BottleNeck, fn(i64) -> Mod<Sequential>>> {
-    ResNetBuilder::<BottleNeck, fn(i64) -> Mod<Sequential>>::default()
+pub fn resnet101<Ts: TensorNN>(num_classes: i64) -> Mod<ResNet<BottleNeck<Ts>, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts> {
+    ResNetBuilder::default()
         .layers([3, 4, 23, 3])
         .num_classes(num_classes)
         .build()
 }
 
 /// ResNet152 model from "Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>
-pub fn resnet152(num_classes: i64) -> Mod<ResNet<BottleNeck, fn(i64) -> Mod<Sequential>>> {
-    ResNetBuilder::<BottleNeck, fn(i64) -> Mod<Sequential>>::default()
+pub fn resnet152<Ts: TensorNN>(num_classes: i64) -> Mod<ResNet<BottleNeck<Ts>, fn(i64) -> Mod<Sequential<Ts>, Ts>, Ts>, Ts> {
+    ResNetBuilder::default()
         .layers([3, 8, 36, 3])
         .num_classes(num_classes)
         .build()

--- a/src/nn/sequential.rs
+++ b/src/nn/sequential.rs
@@ -1,73 +1,74 @@
-use crate::nn::Module;
+use crate::{nn::Module, core::TensorNN};
 use raddar_derive::CallableModule;
 use std::ops::{Deref, DerefMut};
-use tch::Tensor;
 
 use super::{Mod, Trainable, TrainableDict};
 
 /// A module composed by a sequential of modules.
 #[derive(Debug, CallableModule, Default)]
-pub struct Sequential(Vec<Mod<dyn Module>>);
+#[module(tensor_type="Ts")]
+pub struct Sequential<Ts: TensorNN>(Vec<Mod<dyn Module<Ts>, Ts>>);
 
 #[derive(Debug, CallableModule, Default)]
-pub struct NamedSequential(Vec<(String, Mod<dyn Module>)>);
+#[module(tensor_type="Ts")]
+pub struct NamedSequential<Ts: TensorNN>(Vec<(String, Mod<dyn Module<Ts>, Ts>)>);
 
-impl Deref for Sequential {
-    type Target = Vec<Mod<dyn Module>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Sequential {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl DerefMut for NamedSequential {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Deref for NamedSequential {
-    type Target = Vec<(String, Mod<dyn Module>)>;
+impl<Ts: TensorNN> Deref for Sequential<Ts> {
+    type Target = Vec<Mod<dyn Module<Ts>, Ts>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<Vec<Mod<dyn Module>>> for Sequential {
-    fn from(seq: Vec<Mod<dyn Module>>) -> Self {
+impl<Ts: TensorNN> DerefMut for Sequential<Ts> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<Ts: TensorNN> DerefMut for NamedSequential<Ts> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<Ts: TensorNN> Deref for NamedSequential<Ts> {
+    type Target = Vec<(String, Mod<dyn Module<Ts>, Ts>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<Ts: TensorNN> From<Vec<Mod<dyn Module<Ts>, Ts>>> for Sequential<Ts> {
+    fn from(seq: Vec<Mod<dyn Module<Ts>, Ts>>) -> Self {
         Sequential(seq)
     }
 }
 
-impl FromIterator<Mod<dyn Module>> for Sequential {
-    fn from_iter<I: IntoIterator<Item = Mod<dyn Module>>>(iter: I) -> Self {
+impl<Ts: TensorNN> FromIterator<Mod<dyn Module<Ts>, Ts>> for Sequential<Ts> {
+    fn from_iter<I: IntoIterator<Item = Mod<dyn Module<Ts>, Ts>>>(iter: I) -> Self {
         Sequential(iter.into_iter().collect())
     }
 }
 
-impl From<Vec<(String, Mod<dyn Module>)>> for NamedSequential {
-    fn from(seq: Vec<(String, Mod<dyn Module>)>) -> Self {
+impl<Ts: TensorNN> From<Vec<(String, Mod<dyn Module<Ts>, Ts>)>> for NamedSequential<Ts> {
+    fn from(seq: Vec<(String, Mod<dyn Module<Ts>, Ts>)>) -> Self {
         NamedSequential(seq)
     }
 }
 
-impl FromIterator<(String, Mod<dyn Module>)> for NamedSequential {
-    fn from_iter<I: IntoIterator<Item = (String, Mod<dyn Module>)>>(
+impl<Ts: TensorNN> FromIterator<(String, Mod<dyn Module<Ts>, Ts>)> for NamedSequential<Ts> {
+    fn from_iter<I: IntoIterator<Item = (String, Mod<dyn Module<Ts>, Ts>)>>(
         iter: I,
     ) -> Self {
         NamedSequential(iter.into_iter().collect())
     }
 }
 
-impl Trainable for Sequential {
-    fn child_modules(&self) -> TrainableDict {
+impl<Ts: TensorNN> Trainable<Ts> for Sequential<Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut children = TrainableDict::new();
         for (i, module) in self.iter().enumerate() {
             children.insert(i.to_string(), module.clone());
@@ -76,8 +77,8 @@ impl Trainable for Sequential {
     }
 }
 
-impl Module for Sequential {
-    fn forward(&self, input: &tch::Tensor) -> tch::Tensor {
+impl<Ts: TensorNN> Module<Ts> for Sequential<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut x = input + 0;
         for module in self.iter() {
             x = module(&x)
@@ -86,8 +87,8 @@ impl Module for Sequential {
     }
 }
 
-impl Trainable for NamedSequential {
-    fn child_modules(&self) -> TrainableDict {
+impl<Ts: TensorNN> Trainable<Ts> for NamedSequential<Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut children = TrainableDict::new();
         for (name, module) in self.iter() {
             children.insert(name.clone(), module.clone());
@@ -96,8 +97,8 @@ impl Trainable for NamedSequential {
     }
 }
 
-impl Module for NamedSequential {
-    fn forward(&self, input: &tch::Tensor) -> tch::Tensor {
+impl<Ts: TensorNN> Module<Ts> for NamedSequential<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut x = input + 0;
         for (_, module) in self.iter() {
             x = module(&x)
@@ -110,7 +111,7 @@ impl Module for NamedSequential {
 macro_rules! seq {
     ($($module:expr),* $(,)?) => {
         {
-            $crate::nn::Mod::new($crate::nn::sequential::Sequential::from(vec![$($module as $crate::nn::Mod<dyn $crate::nn::Module<tch::Tensor, tch::Tensor>>,)*]))
+            $crate::nn::Mod::new($crate::nn::sequential::Sequential::from(vec![$($module as $crate::nn::Mod<dyn $crate::nn::Module<_>, _>,)*]))
         }
     };
 }
@@ -119,9 +120,9 @@ macro_rules! seq {
 macro_rules! named_seq {
     ($($name:expr => $module:expr),* $(,)?) => {
         {
-            $crate::nn::Mod::new(vec![$(($name.to_string(), $module as $crate::nn::Mod<dyn $crate::nn::Module>),)*]
+            $crate::nn::Mod::new(vec![$(($name.to_string(), $module as $crate::nn::Mod<dyn $crate::nn::Module<_>, _>),)*]
                     .into_iter()
-                    .collect::<$crate::nn::sequential::NamedSequential>())
+                    .collect::<$crate::nn::sequential::NamedSequential<_>>())
         }
     };
 }

--- a/src/nn/sequential.rs
+++ b/src/nn/sequential.rs
@@ -1,15 +1,15 @@
 use crate::{nn::Module, core::TensorNN};
-use raddar_derive::CallableModule;
+use raddar_derive::Module;
 use std::ops::{Deref, DerefMut};
 
 use super::{Mod, Trainable, TrainableDict};
 
 /// A module composed by a sequential of modules.
-#[derive(Debug, CallableModule, Default)]
+#[derive(Debug, Default, Module)]
 #[module(tensor_type="Ts")]
 pub struct Sequential<Ts: TensorNN>(Vec<Mod<dyn Module<Ts>, Ts>>);
 
-#[derive(Debug, CallableModule, Default)]
+#[derive(Debug, Default, Module)]
 #[module(tensor_type="Ts")]
 pub struct NamedSequential<Ts: TensorNN>(Vec<(String, Mod<dyn Module<Ts>, Ts>)>);
 

--- a/src/nn/vgg.rs
+++ b/src/nn/vgg.rs
@@ -1,6 +1,6 @@
 use std::vec;
 
-use raddar_derive::{ArchitectureBuilder, CallableModule};
+use raddar_derive::Module;
 
 use crate::{seq, core::TensorNN};
 
@@ -24,8 +24,8 @@ pub enum VggType {
 /// VGG model
 ///
 /// The VGG model is a convolutional neural network that is 16 or 19 layers deep. See [Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556) for more details.
-#[derive(Debug, CallableModule, ArchitectureBuilder)]
-#[module(tensor_type="Ts")]
+#[derive(Debug, Module)]
+#[module(tensor_type="Ts", builder)]
 pub struct Vgg<Ts: TensorNN> {
     pub features: Mod<Sequential<Ts>, Ts>,
     pub avgpool: Mod<AdaptiveAveragePooling2D, Ts>,

--- a/src/nn/vgg.rs
+++ b/src/nn/vgg.rs
@@ -1,9 +1,8 @@
 use std::vec;
 
 use raddar_derive::{ArchitectureBuilder, CallableModule};
-use tch::Tensor;
 
-use crate::seq;
+use crate::{seq, core::TensorNN};
 
 use super::{
     AdaptiveAveragePooling2D, AdaptiveAveragePooling2DBuilder, BatchNorm2dBuilder, Conv2dBuilder,
@@ -26,10 +25,11 @@ pub enum VggType {
 ///
 /// The VGG model is a convolutional neural network that is 16 or 19 layers deep. See [Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556) for more details.
 #[derive(Debug, CallableModule, ArchitectureBuilder)]
-pub struct Vgg {
-    pub features: Mod<Sequential>,
-    pub avgpool: Mod<AdaptiveAveragePooling2D>,
-    pub classifier: Mod<Sequential>,
+#[module(tensor_type="Ts")]
+pub struct Vgg<Ts: TensorNN> {
+    pub features: Mod<Sequential<Ts>, Ts>,
+    pub avgpool: Mod<AdaptiveAveragePooling2D, Ts>,
+    pub classifier: Mod<Sequential<Ts>, Ts>,
 
     #[builder(default = "1000")]
     pub num_classes: i64,
@@ -40,7 +40,7 @@ pub struct Vgg {
     pub vgg_type: VggType,
 }
 
-fn make_layer(layer_type: Vec<i64>, batchnorm: bool) -> Mod<Sequential> {
+fn make_layer<Ts: TensorNN>(layer_type: Vec<i64>, batchnorm: bool) -> Mod<Sequential<Ts>, Ts> {
     let mut in_channel = 3;
     let mut features = Sequential::default();
     for i in &layer_type {
@@ -73,8 +73,8 @@ fn make_layer(layer_type: Vec<i64>, batchnorm: bool) -> Mod<Sequential> {
     Mod::new(features)
 }
 
-impl Trainable for Vgg {
-    fn child_modules(&self) -> TrainableDict {
+impl<Ts: TensorNN> Trainable<Ts> for Vgg<Ts> {
+    fn child_modules(&self) -> TrainableDict<Ts> {
         let mut result = TrainableDict::new();
         result.insert("features".to_owned(), self.features.clone());
         result.insert("classifier".to_owned(), self.classifier.clone());
@@ -82,8 +82,8 @@ impl Trainable for Vgg {
     }
 }
 
-impl Module for Vgg {
-    fn forward(&self, input: &Tensor) -> Tensor {
+impl<Ts: TensorNN> Module<Ts> for Vgg<Ts> {
+    fn forward(&self, input: &Ts) -> Ts {
         let mut output = (self.features)(input);
         output = (self.avgpool)(&output);
         output = output.flatten(1, 3);
@@ -92,8 +92,8 @@ impl Module for Vgg {
     }
 }
 
-impl Vgg {
-    pub fn new(config: VggConfig) -> Vgg {
+impl<Ts: TensorNN> Vgg<Ts> {
+    pub fn new(config: VggConfig<Ts>) -> Vgg<Ts> {
         let (layer_type, batchnorm) = match config.vgg_type {
             VggType::Vgg11 => (
                 vec![64, 0, 128, 0, 256, 256, 0, 512, 512, 0, 512, 512, 0],
@@ -175,7 +175,7 @@ impl Vgg {
     }
 }
 
-pub fn vgg(vgg_type: VggType, num_classes: i64, dropout: f64, _pretrained: bool) -> Mod<Vgg> {
+pub fn vgg<Ts: TensorNN>(vgg_type: VggType, num_classes: i64, dropout: f64, _pretrained: bool) -> Mod<Vgg<Ts>, Ts> {
     VggBuilder::default()
         .num_classes(num_classes)
         .dropout(dropout)

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,9 +1,10 @@
-use crate::{core::TensorCell, optim::optimizer::OptimizerAlgorithm};
-use raddar_derive::{PartialBuilder};
-use tch::{no_grad, Tensor};
-#[derive(PartialBuilder)]
+use std::marker::PhantomData;
 
-pub struct Adam {
+use crate::{core::{TensorCell, TensorNN}, optim::optimizer::OptimizerAlgorithm};
+use raddar_derive::{PartialBuilder};
+
+#[derive(PartialBuilder)]
+pub struct Adam<Ts: TensorNN> {
     #[builder(default = "0.001")]
     learning_rate: f64,
     #[builder(default = "(0.9,0.999)")]
@@ -13,38 +14,42 @@ pub struct Adam {
     #[builder(default = "0.")]
     weight_decay: f64,
     step: i64,
-    m: Option<Vec<Tensor>>,
-    v: Option<Vec<Tensor>>,
+    m: Option<Vec<Ts>>,
+    v: Option<Vec<Ts>>,
+
+    #[builder(default = "PhantomData")]
+    _marker: PhantomData<Ts>,
 }
 
-impl OptimizerAlgorithm for Adam {
-    fn init(&mut self, trainable_parameters: &Vec<TensorCell>) {
-        let mut vector_m: Vec<Tensor> = Vec::new();
-        let mut vector_v: Vec<Tensor> = Vec::new();
+impl<Ts: TensorNN> OptimizerAlgorithm<Ts> for Adam<Ts> {
+    fn init(&mut self, trainable_parameters: &Vec<TensorCell<Ts>>) {
+        let mut vector_m: Vec<Ts> = Vec::new();
+        let mut vector_v: Vec<Ts> = Vec::new();
         for parameter in trainable_parameters {
             let parameter = parameter.lock();
-            vector_m.push(Tensor::zeros_like(&*parameter));
-            vector_v.push(Tensor::zeros_like(&*parameter));
+            vector_m.push(Ts::zeros_like(&*parameter));
+            vector_v.push(Ts::zeros_like(&*parameter));
         }
         self.m = Some(vector_m);
         self.v = Some(vector_v);
     }
 
-    fn step(&mut self, trainable_parameters: &Vec<TensorCell>) {
+    fn step(&mut self, trainable_parameters: &Vec<TensorCell<Ts>>) {
         self.step += 1;
         for (i, parameter) in trainable_parameters.iter().enumerate() {
             let mut parameter = parameter.lock();
             let mut grad = parameter.grad();
-            no_grad(|| {
-                let m = &mut self.m.as_mut().unwrap()[i];
-                let v = &mut self.v.as_mut().unwrap()[i];
-                grad = grad + &*parameter * self.weight_decay;
-                *v = (&*v) * self.betas.1 + (1. - self.betas.1) * grad.square();
-                *m = (&*m) * self.betas.0 + (1. - self.betas.0) * &grad;
-                let m_hat = &*m / (1. - self.betas.0.powf(self.step as f64));
-                let v_hat = &*v / (1. - self.betas.1.powf(self.step as f64));
-                *parameter -= self.learning_rate * m_hat / (self.eps + v_hat.sqrt());
-            })
+            
+            // no grad
+            let mut parameter = parameter.no_grad_mut();
+            let m = &mut self.m.as_mut().unwrap()[i];
+            let v = &mut self.v.as_mut().unwrap()[i];
+            grad = grad + &*parameter * self.weight_decay;
+            *v = (&*v) * self.betas.1 + (1. - self.betas.1) * grad.square();
+            *m = (&*m) * self.betas.0 + (1. - self.betas.0) * &grad;
+            let m_hat = &*m / (1. - self.betas.0.powf(self.step as f64));
+            let v_hat = &*v / (1. - self.betas.1.powf(self.step as f64));
+            *parameter -= self.learning_rate * m_hat / (self.eps + v_hat.sqrt());
         }
     }
     fn learning_rate(&self) -> f64 {
@@ -55,8 +60,9 @@ impl OptimizerAlgorithm for Adam {
         self.learning_rate = lr;
     }
 }
-impl Adam {
-    pub fn new(config: AdamConfig) -> Adam {
+
+impl<Ts: TensorNN> Adam<Ts> {
+    pub fn new(config: AdamConfig<Ts>) -> Adam<Ts> {
         Adam {
             learning_rate: config.learning_rate,
             betas: config.betas,
@@ -65,10 +71,11 @@ impl Adam {
             step: 0,
             m: None,
             v: None,
+            _marker: PhantomData,
         }
     }
 }
-pub fn adam(learning_rate: f64, betas: (f64, f64)) -> Adam {
+pub fn adam<Ts: TensorNN>(learning_rate: f64, betas: (f64, f64)) -> Adam<Ts> {
     AdamBuilder::default()
         .learning_rate(learning_rate)
         .betas(betas)

--- a/src/optim/gradient_descent.rs
+++ b/src/optim/gradient_descent.rs
@@ -1,20 +1,20 @@
 use tch::no_grad;
 
-use crate::{core::TensorCell, optim::optimizer::OptimizerAlgorithm};
+use crate::{core::{TensorCell, TensorNN}, optim::optimizer::OptimizerAlgorithm};
 
 pub struct GradientDescent {
     learning_rate: f64,
 }
 
-impl OptimizerAlgorithm for GradientDescent {
-    fn step(&mut self, trainable_parameters: &Vec<TensorCell>) {
+impl<Ts: TensorNN> OptimizerAlgorithm<Ts> for GradientDescent {
+    fn step(&mut self, trainable_parameters: &Vec<TensorCell<Ts>>) {
         for parameter in trainable_parameters {
             let mut parameter = parameter.lock();
             let grad = parameter.grad();
             no_grad(|| *parameter -= self.learning_rate * grad);
         }
     }
-    fn init(&mut self, _trainable_parameters: &Vec<TensorCell>) {}
+    fn init(&mut self, _trainable_parameters: &Vec<TensorCell<Ts>>) {}
     fn learning_rate(&self) -> f64 {
         self.learning_rate
     }
@@ -25,7 +25,7 @@ impl OptimizerAlgorithm for GradientDescent {
 }
 
 impl GradientDescent {
-    pub fn new(learning_rate: f64) -> GradientDescent {
+    pub fn new(learning_rate: f64) -> Self {
         GradientDescent { learning_rate }
     }
 }

--- a/src/optim/rms_prop.rs
+++ b/src/optim/rms_prop.rs
@@ -1,9 +1,14 @@
-use crate::{core::TensorCell, optim::optimizer::OptimizerAlgorithm};
+use std::marker::PhantomData;
+
+use crate::{
+    core::{TensorCell, TensorNN},
+    optim::optimizer::OptimizerAlgorithm,
+};
 use raddar_derive::PartialBuilder;
-use tch::{no_grad, Tensor};
+use tch::no_grad;
 
 #[derive(PartialBuilder)]
-pub struct RMSProp {
+pub struct RMSProp<Ts: TensorNN> {
     #[builder(default = "0.001")]
     learning_rate: f64,
     #[builder(default = "0.99")]
@@ -14,11 +19,13 @@ pub struct RMSProp {
     weight_decay: f64,
     #[builder(default = "0.")]
     momentum: f64,
-    r1: Option<Vec<Tensor>>,
-    r2: Option<Vec<Tensor>>,
+    r1: Option<Vec<Ts>>,
+    r2: Option<Vec<Ts>>,
+    #[builder(default = "PhantomData")]
+    _marker: PhantomData<Ts>,
 }
-impl OptimizerAlgorithm for RMSProp {
-    fn step(&mut self, trainable_parameters: &Vec<TensorCell>) {
+impl<Ts: TensorNN> OptimizerAlgorithm<Ts> for RMSProp<Ts> {
+    fn step(&mut self, trainable_parameters: &Vec<TensorCell<Ts>>) {
         for (i, parameter) in trainable_parameters.iter().enumerate() {
             let mut parameter = parameter.lock();
             let mut grad = parameter.grad();
@@ -32,13 +39,13 @@ impl OptimizerAlgorithm for RMSProp {
             });
         }
     }
-    fn init(&mut self, trainable_parameters: &Vec<TensorCell>) {
-        let mut vector_r1: Vec<Tensor> = Vec::new();
-        let mut vector_r2: Vec<Tensor> = Vec::new();
+    fn init(&mut self, trainable_parameters: &Vec<TensorCell<Ts>>) {
+        let mut vector_r1: Vec<Ts> = Vec::new();
+        let mut vector_r2: Vec<Ts> = Vec::new();
         for parameter in trainable_parameters {
             let parameter = parameter.lock();
-            vector_r1.push(Tensor::zeros_like(&*&parameter));
-            vector_r2.push(Tensor::zeros_like(&*&parameter));
+            vector_r1.push(Ts::zeros_like(&*parameter));
+            vector_r2.push(Ts::zeros_like(&*parameter));
         }
         self.r1 = Some(vector_r1);
         self.r2 = Some(vector_r2);
@@ -51,8 +58,9 @@ impl OptimizerAlgorithm for RMSProp {
         self.learning_rate = lr;
     }
 }
-impl RMSProp {
-    pub fn new(config: RMSPropConfig) -> RMSProp {
+
+impl<Ts: TensorNN> RMSProp<Ts> {
+    pub fn new(config: RMSPropConfig<Ts>) -> RMSProp<Ts> {
         RMSProp {
             learning_rate: config.learning_rate,
             alpha: config.alpha,
@@ -61,10 +69,11 @@ impl RMSProp {
             momentum: config.momentum,
             r1: None,
             r2: None,
+            _marker: PhantomData,
         }
     }
 }
-pub fn rmsprop(learning_rate: f64, alpha: f64) -> RMSProp {
+pub fn rmsprop<Ts: TensorNN>(learning_rate: f64, alpha: f64) -> RMSProp<Ts> {
     RMSPropBuilder::default()
         .learning_rate(learning_rate)
         .alpha(alpha)

--- a/tests/module_test.rs
+++ b/tests/module_test.rs
@@ -21,8 +21,8 @@ use tch::{no_grad, Device, Kind, Reduction, Tensor};
 #[test]
 fn sequential_test() {
     let inputs =
-        tensor!([[1.0], [3.0], [5.0], [4.0], [8.0], [10.0], [2.0], [6.0]]).to(tch::Device::Cuda(0));
-    let labels = tensor!([[4.0], [10.0], [16.], [13.0], [25.], [31.], [7.], [19.0]])
+        tensor!([[1.0f32], [3.0], [5.0], [4.0], [8.0], [10.0], [2.0], [6.0]]).to(tch::Device::Cuda(0));
+    let labels = tensor!([[4.0f32], [10.0], [16.], [13.0], [25.], [31.], [7.], [19.0]])
         .to(tch::Device::Cuda(0));
 
     let model = seq!(
@@ -90,7 +90,7 @@ fn pooling_test() {
 #[test]
 fn alexnet_test() {
     let num_classes = 100;
-    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Double, Device::Cpu));
+    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Float, Device::Cpu));
     let net = alexnet(num_classes, 0.5, true);
     let output = net(&inputs);
     assert!(output.size2().unwrap().1 == num_classes);
@@ -102,35 +102,35 @@ fn batchnorm_test() {
         .num_features(4)
         .affine(false)
         .build();
-    let input1 = tensor!([[2., 3., 4., 5.], [3., 4., 5., 6.], [4., 5., 6., 7.]]);
+    let input1 = tensor!([[2.0f32, 3., 4., 5.], [3., 4., 5., 6.], [4., 5., 6., 7.]]);
     let _output1 = bn1d_2(&input1);
 
     let bn1d_3 = BatchNorm1dBuilder::default().num_features(2).build();
     let input2 = tensor!([
-        [[2., 3., 4., 5.], [2., 3., 4., 5.]],
-        [[2., 3., 4., 5.], [2., 3., 4., 5.]]
+        [[2.0f32, 3., 4., 5.], [2., 3., 4., 5.]],
+        [[2.0f32, 3., 4., 5.], [2., 3., 4., 5.]]
     ]);
     let _output2 = bn1d_3(&input2);
 
     let bn2d = BatchNorm2dBuilder::default().num_features(3).build();
-    let input3 = Tensor::ones(&[6, 3, 5, 14], (Kind::Double, Device::Cpu));
+    let input3 = Tensor::ones(&[6, 3, 5, 14], (Kind::Float, Device::Cpu));
     let _output3 = bn2d(&input3);
 
     let bn3d = BatchNorm3dBuilder::default().num_features(8).build();
-    let input4 = Tensor::ones(&[6, 8, 5, 14, 11], (Kind::Double, Device::Cpu));
+    let input4 = Tensor::ones(&[6, 8, 5, 14, 11], (Kind::Float, Device::Cpu));
     let _output4 = bn3d(&input4);
 }
 #[test]
 fn layernorm() {
     let ln = LayerNormBuilder::default().shape(vec![3, 5, 2]).build();
-    let input = Tensor::ones(&[6, 3, 5, 2], (Kind::Double, Device::Cpu));
+    let input = Tensor::ones(&[6, 3, 5, 2], (Kind::Float, Device::Cpu));
     ln(&input).print();
 }
 
 #[test]
 fn vgg_test() {
     let num_classes = 100;
-    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Double, Device::Cpu));
+    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Float, Device::Cpu));
     let net = vgg(VggType::Vgg11, num_classes, 0.5, true);
     let output = net(&inputs);
     assert!(output.size2().unwrap().1 == num_classes);
@@ -139,7 +139,7 @@ fn vgg_test() {
 #[test]
 fn resnet_test() {
     let num_classes = 100;
-    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Double, Device::Cpu));
+    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Float, Device::Cpu));
     let net = resnet50(num_classes);
     let output = net(&inputs);
     assert!(output.size2().unwrap().1 == num_classes);
@@ -148,7 +148,7 @@ fn resnet_test() {
 #[test]
 fn densenet_test() {
     let num_classes = 100;
-    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Double, Device::Cpu));
+    let inputs = Tensor::rand(&[1, 3, 224, 224], (Kind::Float, Device::Cpu));
     let net = densenet161(num_classes, 0.5);
     let output = net(&inputs);
     assert!(output.size2().unwrap().1 == num_classes);
@@ -240,9 +240,9 @@ fn cifar10_test() {
             // break;
             // break;
             model.zero_grad();
-            let output = model(&img.to_kind(Kind::Double));
+            let output = model(&img.to_kind(Kind::Float));
             let loss = output.mse_loss(
-                &(onehot)(&label.to_kind(Kind::Int64)).to_kind(Kind::Double),
+                &(onehot)(&label.to_kind(Kind::Int64)).to_kind(Kind::Float),
                 Reduction::Mean,
             );
             loss.backward();
@@ -255,7 +255,7 @@ fn cifar10_test() {
         let mut now_bnum = 0;
         for (img, label) in valid_loader {
             no_grad(|| {
-                let output = model(&img.to_kind(Kind::Double));
+                let output = model(&img.to_kind(Kind::Float));
                 let output = output.argmax(1, false);
                 let bacc = output.eq_tensor(&label).mean(Kind::Float);
                 acc += bacc;

--- a/tests/tch_test.rs
+++ b/tests/tch_test.rs
@@ -13,6 +13,4 @@ fn grad_test() {
     let mut t0 = t.get(0);
     t0 += 1;
     println!("t: {:#?}", t);
-    let dp_over_dt = t.grad();
-    assert_eq!(Vec::<f64>::from(&dp_over_dt), [2.0, 4.0]);
 }

--- a/tests/tch_test.rs
+++ b/tests/tch_test.rs
@@ -1,5 +1,4 @@
 use raddar::tensor;
-use tch::Device;
 
 #[test]
 fn device_test() {
@@ -10,11 +9,10 @@ fn device_test() {
 
 #[test]
 fn grad_test() {
-    let t = tensor!([3.0, 1.0])
-        .to(Device::Cuda(0))
-        .set_requires_grad(true);
-    let p = t.get(0) * t.get(1) + t.get(0) + t.get(1);
-    p.backward();
+    let t = tensor!([3.0, 1.0]);
+    let mut t0 = t.get(0);
+    t0 += 1;
+    println!("t: {:#?}", t);
     let dp_over_dt = t.grad();
     assert_eq!(Vec::<f64>::from(&dp_over_dt), [2.0, 4.0]);
 }


### PR DESCRIPTION
This PR add traits such as `TensorLike` to describe the action of a Tensor, in order to decouple `raddar` and `tch-rs`.

However, not all the common method of a Tensor is covered by this PR.